### PR TITLE
Nuclear potential update: added support for quadrupole deformation and reading custom nuclear potentials

### DIFF
--- a/src/Physics/NuclearData.cpp
+++ b/src/Physics/NuclearData.cpp
@@ -93,6 +93,14 @@ double rrms_formula_c_t(double c, double t)
   return std::sqrt((3.0 / 5.0) * c * c + (7.0 / 5.0) * a * a * Pi2);
 }
 
+double deformation_effective_t(double c, double t, double beta)
+// Nuclear quadrupole deformation is approximately equivalent
+// to change in skin thickness (see, e.g., Eq. 8 10.1103/PhysRevA.100.032511)
+{
+  const double sqrt_delta_t = FourLn3 * c * beta;
+  return std::sqrt(t * t + 3.0 / (4.0 * M_PI * M_PI * M_PI) * sqrt_delta_t * sqrt_delta_t);
+}
+
 //==============================================================================
 
 double approximate_t_skin(int) { return default_t; }

--- a/src/Physics/NuclearData.hpp
+++ b/src/Physics/NuclearData.hpp
@@ -51,8 +51,12 @@ double c_hdr_formula_rrms_t(double rrms, double t = default_t);
 //! Calculates rrms from c and t
 double rrms_formula_c_t(double c, double t = default_t);
 
-//! Aproximate rms radius from a fir to Angeli data
+//! Approximate rms radius from a for to Angeli data
 double approximate_r_rms(int a, int z);
+
+//! Calculates effective skin thickness due to quadrupole deformation.
+double deformation_effective_t(double c, double t, double beta);
+
 //! just returns 2.3
 double approximate_t_skin(int a);
 

--- a/src/Physics/NuclearPotentials.cpp
+++ b/src/Physics/NuclearPotentials.cpp
@@ -30,7 +30,7 @@ ChargeDistro parseType(const std::string &str_type) {
     return ChargeDistro::Gaussian;
   if (qip::ci_wc_compare(str_type, "custom"))
     return ChargeDistro::custom;
-  std::cout << "\n!!  WARNING: Unkown nucleus type: " << str_type << "\n";
+  std::cout << "\n!!  WARNING: Unknown nucleus type: " << str_type << "\n";
 
   // spelling suggestions:
   std::cout << "Did you mean: "
@@ -65,8 +65,8 @@ Nucleus::Nucleus(int tz, int ta, const std::string &str_type, double trrms,
     : m_iso(findIsotopeData(tz, ta < 0 ? AtomData::defaultA(tz) : ta)),
       m_type(parseType(str_type)),
       m_t(tt),
-      m_params(in_params),
-      m_custom_pot_file_name(custom_pot_file_name) {
+      m_custom_pot_file_name(custom_pot_file_name),
+      m_params(in_params) {
 
   if (m_type != ChargeDistro::Fermi)
     m_t = 0.0;

--- a/src/Physics/NuclearPotentials.cpp
+++ b/src/Physics/NuclearPotentials.cpp
@@ -28,15 +28,17 @@ ChargeDistro parseType(const std::string &str_type) {
     return ChargeDistro::point;
   if (qip::ci_wc_compare(str_type, "gaus*"))
     return ChargeDistro::Gaussian;
+  if (qip::ci_wc_compare(str_type, "custom"))
+    return ChargeDistro::custom;
   std::cout << "\n!!  WARNING: Unkown nucleus type: " << str_type << "\n";
 
   // spelling suggestions:
   std::cout << "Did you mean: "
             << *qip::ci_closest_match(str_type, {"Fermi", "spherical", "ball",
-                                                 "pointlike", "Gaussian"})
+                                                 "pointlike", "Gaussian", "custom"})
             << " ?\n ";
   std::cout << "Options are: Fermi, spherical (or ball, uniform), pointlike, "
-               "Gaussian\n\n";
+               "Gaussian, or custom (requires readable input file)\n\n";
 
   return ChargeDistro::Error;
 }
@@ -51,16 +53,20 @@ std::string parseType(ChargeDistro type) {
     return "pointlike";
   if (type == ChargeDistro::Gaussian)
     return "Gaussian";
+  if (type == ChargeDistro::custom)
+    return "custom";
   return "Error";
 }
 
 //==============================================================================
 Nucleus::Nucleus(int tz, int ta, const std::string &str_type, double trrms,
-                 double tt, const std::vector<double> &in_params)
+                 double tt, const std::vector<double> &in_params,
+                 const std::string & potential_if_name)
     : m_iso(findIsotopeData(tz, ta < 0 ? AtomData::defaultA(tz) : ta)),
       m_type(parseType(str_type)),
       m_t(tt),
-      m_params(in_params) {
+      m_params(in_params),
+      m_potential_if_name(potential_if_name) {
 
   if (m_type != ChargeDistro::Fermi)
     m_t = 0.0;
@@ -86,9 +92,10 @@ Nucleus::Nucleus(int tz, int ta, const std::string &str_type, double trrms,
 
 Nucleus::Nucleus(const std::string &z_str, int in_a,
                  const std::string &str_type, double in_rrms, double in_t,
-                 const std::vector<double> &in_params)
+                 const std::vector<double> &in_params,
+                 const std::string & potential_if_name)
     : Nucleus(AtomData::atomic_Z(z_str), in_a, str_type, in_rrms, in_t,
-              in_params) {}
+              in_params, potential_if_name) {}
 
 //==============================================================================
 std::ostream &operator<<(std::ostream &ostr, const Nucleus &n) {
@@ -114,6 +121,11 @@ std::ostream &operator<<(std::ostream &ostr, const Nucleus &n) {
          << " r_rms = " << rrms
          << ", c_hdr = " << Nuclear::c_hdr_formula_rrms_t(rrms, tt)
          << ", t = " << tt;
+    break;
+    case Nuclear::ChargeDistro::custom:
+    ostr << "Custom nuclear potential; "
+         << "file = \'" << n.potential_if_name()
+         << "\'.\n";
     break;
   default:
     ostr << "Invalid nucleus type?";
@@ -144,10 +156,11 @@ Nucleus form_nucleus(int Z, std::optional<int> tA, IO::InputBlock input) {
              "over-ride rms). Default "
              "depends on Z and A."},
        {"t", "Nuclear skin thickness, in fm [2.3]"},
-       {"type", "Fermi, spherical, pointlike, Gaussian [Fermi]"},
+       {"type", "Fermi, spherical, point-like, Gaussian [Fermi], custom"},
+       {"input_file", "Input text file containing nuclear potential grid values to use."},
        {"parameters",
-        "List of comma separated real numbers. Not currently unsed, but may "
-        "be used in futur for more complicated nuclear distros."}});
+        "List of comma separated real numbers. Not currently unused, but may "
+        "be used in future for more complicated nuclear distros."}});
 
   using namespace std::string_literals;
   // Set nuclear type if given
@@ -163,6 +176,9 @@ Nucleus form_nucleus(int Z, std::optional<int> tA, IO::InputBlock input) {
   const auto rrms = input.get<double>("rrms");
   const auto t = input.get<double>("t");
   const auto c_hdr = input.get<double>("c");
+
+  const auto input_file = input.get<std::string>("input_file");
+
   if (t) {
     nucleus.t() = *t;
   }
@@ -174,10 +190,14 @@ Nucleus form_nucleus(int Z, std::optional<int> tA, IO::InputBlock input) {
     nucleus.set_rrms(Nuclear::rrms_formula_c_t(*c_hdr, nucleus.t()));
   }
 
+  if (input_file) {
+    nucleus.set_potential_if_name(*input_file);
+  }
+
   // Set "extra" parameters (not currently used)
   nucleus.params() = input.get<std::vector<double>>("parameters", {});
 
-  // If A or given rrms are zero, explicitely set to pointlike nucleus
+  // If A or given rrms are zero, explicitly set to point-like nucleus
   // This isn't required, but makes output more explicit
   if (nucleus.a() == 0.0 || nucleus.r_rms() == 0.0) {
     nucleus.t() = 0.0;
@@ -197,7 +217,7 @@ std::vector<double> sphericalNuclearPotential(double Z, double rnuc,
   std::vector<double> vnuc;
   vnuc.reserve(rgrid.size());
 
-  // Fill the vnuc array with spherical nuclear potantial
+  // Fill the vnuc array with spherical nuclear potential
   const double rN = rnuc / PhysConst::aB_fm; // convert fm -> au
   const double rn2 = rN * rN;
   const double rn3 = rn2 * rN;
@@ -218,7 +238,7 @@ std::vector<double> GaussianNuclearPotential(double Z, double r_rms,
   std::vector<double> vnuc;
   vnuc.reserve(rgrid.size());
 
-  // Fill the vnuc array with Gaussian nuclear potantial
+  // Fill the vnuc array with Gaussian nuclear potential
   const double rN = r_rms / PhysConst::aB_fm; // convert fm -> au
   const auto k = std::sqrt(3.0 / 2);
   for (auto r : rgrid) {
@@ -238,7 +258,7 @@ std::vector<double> fermiNuclearPotential(double z, double t, double c,
 //   A = Int[ rho(x) x^2 , {x,0,r}]
 //   B = r * Int[ rho(x) x , {x,r,infty}]
 // rho_0 is found by either:
-//   * V(infinity) = -Z/r , or equivilantly
+//   * V(infinity) = -Z/r , or equivalently
 //   * int rho(r) d^3r = Z
 //
 // Depends on:
@@ -246,9 +266,9 @@ std::vector<double> fermiNuclearPotential(double z, double t, double c,
 //     note: t = a[4 ln(3)]
 //   * c: half-density radius (see above for link c and r_rms)
 //
-// t and c are input values. In 'fermi' or fm (fempto metres)
+// t and c are input values. In 'fermi' or fm (femto metres)
 //
-// V(r) is expressed in terms of Complete Fermi-Dirac intagrals.
+// V(r) is expressed in terms of Complete Fermi-Dirac integrals.
 // These are computed using the GSL libraries.
 // gnu.org/software/gsl/manual/html_node/Complete-Fermi_002dDirac-Integrals
 {
@@ -262,7 +282,7 @@ std::vector<double> fermiNuclearPotential(double z, double t, double c,
   for (auto r : rgrid) {
     double t_v = -z / r;
     const double roa = PhysConst::aB_fm * r / a; // convert fm <-> atomic
-    const double roc = r / c * PhysConst::aB_fm;
+    const double roc = PhysConst::aB_fm * r / c;
     if (roc < 10.0) {
       const auto coa2 = coa * coa;
       const auto roa3 = roa * roa * roa;
@@ -313,6 +333,31 @@ std::vector<double> fermiNuclearDensity_tcN(double t, double c, double Z_norm,
   return rho;
 }
 
+std::vector<double> readCustomNuclearPotential(const std::string& if_name, std::size_t rgrid_size)
+{
+  std::vector<double> vnuc;
+  vnuc.reserve(rgrid_size);
+  
+  std::ifstream potential_fstream;
+  potential_fstream.open(if_name);
+  double current_value = 0.0;
+
+  // Consistency check to ensure the potential grid has the same number of points as the radial grid.
+  std::size_t number_lines = 0;
+  while (potential_fstream >> current_value) {
+      vnuc.push_back(current_value);
+      ++number_lines;
+  }
+  if(number_lines == rgrid_size) {
+    return vnuc;
+  }
+  else {
+    std::cout << "Error: provided nuclear potential file: \"" << if_name << "\" has incompatible size"
+              << " (expected " << rgrid_size << ", got " << number_lines << ").";
+    std::abort();
+  }
+}
+
 //==============================================================================
 std::vector<double> formPotential(const Nucleus &nuc,
                                   const std::vector<double> &r) {
@@ -345,6 +390,10 @@ std::vector<double> formPotential(const Nucleus &nuc,
 
   case Nuclear::ChargeDistro::Gaussian: {
     return Nuclear::GaussianNuclearPotential(z, r_rms, r);
+  }
+
+  case Nuclear::ChargeDistro::custom: {
+    return Nuclear::readCustomNuclearPotential(nuc.potential_if_name(), r.size());
   }
 
   default: {

--- a/src/Physics/NuclearPotentials.cpp
+++ b/src/Physics/NuclearPotentials.cpp
@@ -65,6 +65,7 @@ Nucleus::Nucleus(int tz, int ta, const std::string &str_type, double trrms,
     : m_iso(findIsotopeData(tz, ta < 0 ? AtomData::defaultA(tz) : ta)),
       m_type(parseType(str_type)),
       m_t(tt),
+      m_beta(0.0),
       m_custom_pot_file_name(custom_pot_file_name),
       m_params(in_params) {
 

--- a/src/Physics/NuclearPotentials.cpp
+++ b/src/Physics/NuclearPotentials.cpp
@@ -60,12 +60,12 @@ std::string parseType(ChargeDistro type) {
 
 //==============================================================================
 Nucleus::Nucleus(int tz, int ta, const std::string &str_type, double trrms,
-                 double tt, const std::vector<double> &in_params,
+                 double tt, double in_beta, const std::vector<double> &in_params,
                  const std::string & custom_pot_file_name)
     : m_iso(findIsotopeData(tz, ta < 0 ? AtomData::defaultA(tz) : ta)),
       m_type(parseType(str_type)),
       m_t(tt),
-      m_beta(0.0),
+      m_beta(in_beta),
       m_custom_pot_file_name(custom_pot_file_name),
       m_params(in_params) {
 
@@ -92,10 +92,10 @@ Nucleus::Nucleus(int tz, int ta, const std::string &str_type, double trrms,
 }
 
 Nucleus::Nucleus(const std::string &z_str, int in_a,
-                 const std::string &str_type, double in_rrms, double in_t,
+                 const std::string &str_type, double in_rrms, double in_t, double in_beta,
                  const std::vector<double> &in_params,
                  const std::string & custom_pot_file_name)
-    : Nucleus(AtomData::atomic_Z(z_str), in_a, str_type, in_rrms, in_t,
+    : Nucleus(AtomData::atomic_Z(z_str), in_a, str_type, in_rrms, in_t, in_beta,
               in_params, custom_pot_file_name) {}
 
 //==============================================================================

--- a/src/Physics/NuclearPotentials.hpp
+++ b/src/Physics/NuclearPotentials.hpp
@@ -97,9 +97,6 @@ fermiNuclearPotential(double Z, double t, double c,
 [[nodiscard]] std::vector<double>
 fermiNuclearDensity_tcN(double t, double c, double Z_norm, const Grid &grid);
 
-[[nodiscard]] std::vector<double>
-readCustomNuclearPotential(const std::string& if_name, std::size_t rgrid_size);
-
 //! Calls one of the above, depending on params. Fills V(r), given r
 [[nodiscard]] std::vector<double> formPotential(const Nucleus &nucleus,
                                                 const std::vector<double> &r);

--- a/src/Physics/NuclearPotentials.hpp
+++ b/src/Physics/NuclearPotentials.hpp
@@ -24,8 +24,10 @@ class Nucleus {
   Nuclear::ChargeDistro m_type;
   // skin thickness parameter (in fm). Usually 2.3
   double m_t;
+  // Deformation parameter beta. Usually 0.
+  double m_beta;
   // Name of input file used to read in custom nuclear potential
-  std::string m_potential_if_name;
+  std::string m_custom_pot_file_name;
   // Other parameters: not used for now
   std::vector<double> m_params;
 
@@ -33,13 +35,13 @@ public:
   Nucleus(int in_z = 1, int in_a = 0, const std::string &str_type = "Fermi",
           double in_rrms = -1.0, double in_t = -1.0,
           const std::vector<double> &in_params = {},
-          const std::string & potential_if_name = "");
+          const std::string & custom_pot_file_name = "");
 
   Nucleus(const std::string &z_str, int in_a,
           const std::string &str_type = "Fermi", double in_rrms = -1.0,
           double in_t = Nuclear::default_t,
           const std::vector<double> &in_params = {},
-          const std::string & potential_if_name = "");
+          const std::string & custom_pot_file_name = "");
 
 public:
   ChargeDistro &type() { return m_type; }
@@ -58,8 +60,11 @@ public:
   double &t() { return m_t; };
   double t() const { return m_t; };
 
-  void set_potential_if_name(const std::string& name) { m_potential_if_name = name; };
-  std::string potential_if_name() const {return m_potential_if_name; };
+  double &beta() { return m_beta; };
+  double beta() const { return m_beta; };
+
+  std::string& custom_pot_file() { return m_custom_pot_file_name; };
+  std::string custom_pot_file() const {return m_custom_pot_file_name; };
 
   double c() const { return c_hdr_formula_rrms_t(r_rms(), m_t); }
 

--- a/src/Physics/NuclearPotentials.hpp
+++ b/src/Physics/NuclearPotentials.hpp
@@ -9,7 +9,7 @@ class Grid;
 namespace Nuclear {
 
 //! Nuclear charge distribution options
-enum class ChargeDistro { Fermi, spherical, point, Gaussian, Error };
+enum class ChargeDistro { Fermi, spherical, point, Gaussian, custom, Error };
 
 ChargeDistro parseType(const std::string &str_type);
 std::string parseType(ChargeDistro type);
@@ -24,18 +24,22 @@ class Nucleus {
   Nuclear::ChargeDistro m_type;
   // skin thickness parameter (in fm). Usually 2.3
   double m_t;
+  // Name of input file used to read in custom nuclear potential
+  std::string m_potential_if_name;
   // Other parameters: not used for now
   std::vector<double> m_params;
 
 public:
   Nucleus(int in_z = 1, int in_a = 0, const std::string &str_type = "Fermi",
           double in_rrms = -1.0, double in_t = -1.0,
-          const std::vector<double> &in_params = {});
+          const std::vector<double> &in_params = {},
+          const std::string & potential_if_name = "");
 
   Nucleus(const std::string &z_str, int in_a,
           const std::string &str_type = "Fermi", double in_rrms = -1.0,
           double in_t = Nuclear::default_t,
-          const std::vector<double> &in_params = {});
+          const std::vector<double> &in_params = {},
+          const std::string & potential_if_name = "");
 
 public:
   ChargeDistro &type() { return m_type; }
@@ -53,6 +57,9 @@ public:
 
   double &t() { return m_t; };
   double t() const { return m_t; };
+
+  void set_potential_if_name(const std::string& name) { m_potential_if_name = name; };
+  std::string potential_if_name() const {return m_potential_if_name; };
 
   double c() const { return c_hdr_formula_rrms_t(r_rms(), m_t); }
 
@@ -85,8 +92,12 @@ fermiNuclearPotential(double Z, double t, double c,
 [[nodiscard]] std::vector<double>
 fermiNuclearDensity_tcN(double t, double c, double Z_norm, const Grid &grid);
 
+[[nodiscard]] std::vector<double>
+readCustomNuclearPotential(const std::string& if_name, std::size_t rgrid_size);
+
 //! Calls one of the above, depending on params. Fills V(r), given r
 [[nodiscard]] std::vector<double> formPotential(const Nucleus &nucleus,
                                                 const std::vector<double> &r);
+
 
 } // namespace Nuclear

--- a/src/Physics/NuclearPotentials.hpp
+++ b/src/Physics/NuclearPotentials.hpp
@@ -33,13 +33,13 @@ class Nucleus {
 
 public:
   Nucleus(int in_z = 1, int in_a = 0, const std::string &str_type = "Fermi",
-          double in_rrms = -1.0, double in_t = -1.0,
+          double in_rrms = -1.0, double in_t = -1.0, double in_beta = 0.0,
           const std::vector<double> &in_params = {},
           const std::string & custom_pot_file_name = "");
 
   Nucleus(const std::string &z_str, int in_a,
           const std::string &str_type = "Fermi", double in_rrms = -1.0,
-          double in_t = Nuclear::default_t,
+          double in_t = Nuclear::default_t, double in_beta = 0.0,
           const std::vector<double> &in_params = {},
           const std::string & custom_pot_file_name = "");
 


### PR DESCRIPTION
### 5256983: Read in a potential from a user-specified text file
Notes:
- Specify using `Nuclear::ChargeDistro::custom`.
- File is read in using `Nuclear::readCustomNuclearPotential`.
- Expects a single-column text file with values corresponding to nuclear potential evaluated on the _same grid_ that will be used to solve wavefunctions.

### 3b908e0: Evaluate fermi nuclear potential with effective skin-thickness induced by quadrupole deformation.
Notes:
- See Eq. 8 of [https://doi.org/10.1103/PhysRevA.100.032511](10.1103/PhysRevA.100.032511).
