### PR TITLE
Add frequency-dependent Breit less two-body matrix elements and direct part of the potential

### DIFF
--- a/src/Coulomb/CoulombIntegrals.cpp
+++ b/src/Coulomb/CoulombIntegrals.cpp
@@ -2,6 +2,8 @@
 #include "Angular/include.hpp"
 #include "Maths/Grid.hpp"
 #include "Maths/NumCalc_quadIntegrate.hpp"
+#include "Maths/SphericalBessel.hpp"
+#include "Physics/PhysConst_constants.hpp"
 #include "Wavefunction/DiracSpinor.hpp"
 #include "qip/Maths.hpp"
 #include "qip/Vector.hpp"
@@ -176,6 +178,251 @@ static inline void yk_ijk_gen_impl(const int l, const Function &ff,
 }
 
 //------------------------------------------------------------------------------
+
+// Used for frequency-dependent Breit
+template <int k, typename Function>
+static inline void
+yk_ijk_gen_impl_freq(const int l, const Function &ff, const Grid &gr,
+                     std::vector<double> &v0, std::vector<double> &vi,
+                     const std::size_t maxi, const double w) {
+  const auto du = gr.du();
+  const auto num_points = gr.num_points();
+  v0.resize(num_points); // for safety
+  vi.resize(num_points); // for safety
+  const auto irmax = (maxi == 0 || maxi > num_points) ? num_points : maxi;
+
+  // Quadrature integration weights:
+  const auto weights = [=](std::size_t i) {
+    if (i < NumCalc::Nquad)
+      return NumCalc::dq_inv * NumCalc::cq[i];
+    if (i < num_points - NumCalc::Nquad)
+      return 1.0;
+    return NumCalc::dq_inv * NumCalc::cq[num_points - i - 1];
+  };
+
+  const auto &r = gr.r();
+
+  auto jkwr_func = [](const int &l, const double &w, const double &r) {
+    return SphericalBessel::exactGSL_JL_alt(l, w * r);
+  };
+  auto ykwr_func = [](const int &l, const double &w, const double &r) {
+    return SphericalBessel::exactGSL_YL_alt(l, w * r);
+  };
+
+  // fills vector with spherical Bessel functions of first kind j_k(\alpha*\omega*r)
+  //const auto jkwr = SphericalBessel::fillBesselVec_kr_alt(l, w, r);
+
+  // fills vector with spherical Bessel functions of second kind y_k(\alpha*\omega*r)
+  //const auto ykwr = SphericalBessel::fillSecondBesselVec_kr_alt(l, w, r);
+
+  // values to keep running track of numerical integrals
+  double Ax = 0.0;
+  double Bx = 0.0;
+
+  // performs numerical integral from r'=0 to r'=r using single for loop trick
+  v0[0] = 0.0;
+  for (std::size_t i = 1; i < irmax; ++i) {
+    Ax = Ax + jkwr_func(k, w, r[i - 1]) * ff(i - 1) * weights(i - 1) *
+                gr.drdu(i - 1);
+    v0[i] = -w * (2 * k + 1.0) * ykwr_func(k, w, r[i]) * Ax * du;
+  }
+  for (std::size_t i = irmax; i < num_points; i++) {
+    v0[i] = 0.0;
+  }
+
+  // nb bmax may be num_points
+  const auto bmax = irmax;
+  for (std::size_t i = 0; i <= bmax; i++) {
+    vi[i] = 0.0;
+  }
+  const auto rbmax =
+    bmax == num_points ? r.back() + gr.drdu().back() * du : r[bmax];
+
+  Bx = Bx + ykwr_func(k, w, r[bmax - 1]) * ff(bmax - 1) * gr.drdu(bmax - 1);
+
+  vi[bmax - 1] = -w * (2.0 * k + 1.0) * jkwr_func(k, w, r[bmax - 1]) * Bx * du;
+
+  // loop for the integral that goes from r'=r up to r<infinity
+  // in this loop I have to shift the index up by 1 so that i goes down to i>=1 rather than i>=0, since it freaks out when I do the latter, for some reason
+  for (auto i = bmax - 1; i >= 1; i--) {
+    Bx = Bx + ykwr_func(k, w, r[i - 1]) * ff(i - 1) * weights(i - 1) *
+                gr.drdu(i - 1);
+    vi[i - 1] = -w * (2 * k + 1.0) * jkwr_func(k, w, r[i - 1]) * Bx * du;
+  }
+}
+
+//---------------------------------------------------------------------------------
+
+// function for calculating the Breit frequency-dependent screening factor vkabcd(w) - stores first term v1 and second term v2 separately
+template <int k>
+static inline void
+vkabcd_freqw(const int l, const std::vector<double> &Pkbd,
+             const std::vector<double> &Qkbd, const Grid &gr,
+             std::vector<double> &v1, std::vector<double> &v2,
+             std::vector<double> &v3, std::vector<double> &v4,
+             const std::size_t maxi, const double w) {
+
+  bool cut_off = w <= PhysConst::alpha;
+  // bool cut_off = true;
+  // bool cut_off = false;
+
+  const auto du = gr.du();
+  const auto num_points = gr.num_points();
+  v1.resize(num_points); // for safety
+  v2.resize(num_points); // for safety
+  v3.resize(num_points); // for safety
+  v4.resize(num_points); // for safety
+  const auto irmax = (maxi == 0 || maxi > num_points) ? num_points : maxi;
+
+  // faster method to calculate r^k
+  const auto powk = [l]() {
+    if constexpr (k < 0) {
+      return [l](double x) { return std::pow(x, l); };
+    } else {
+      (void)l; // l not used
+      return qip::pow<k, double>;
+    }
+  }();
+
+  // Quadrature integration weights:
+  const auto weights = [=](std::size_t i) {
+    if (i < NumCalc::Nquad)
+      return NumCalc::dq_inv * NumCalc::cq[i];
+    if (i < num_points - NumCalc::Nquad)
+      return 1.0;
+    return NumCalc::dq_inv * NumCalc::cq[num_points - i - 1];
+  };
+
+  const auto &r = gr.r();
+
+  auto jkwr = [](const int &l, const double &w, const double &r) {
+    // return SphericalBessel::exactGSL_JL_alt(l, w * r);
+    return SphericalBessel::exactGSL_JL_alt(l, w * r);
+  };
+  auto ykwr = [](const int &l, const double &w, const double &r) {
+    // return SphericalBessel::exactGSL_YL(l, w * r);
+    return SphericalBessel::exactGSL_YL_alt(l, w * r);
+  };
+
+  // values to keep running track of numerical integrals
+  double A1 = 0.0;
+  double A2 = 0.0;
+  double C1 = 0.0;
+  double A3 = 0.0;
+
+  const double wsd2 = w * w / 2.0;
+  const double wcubed = w * w * w;
+  const double odw2 = 1.0 / (w * w);
+
+  // performs numerical integrals for v1 and v2
+  v1[0] = 0.0;
+  v2[0] = 0.0;
+  for (std::size_t i = 1; i < irmax; ++i) {
+
+    double ratio = r[i - 1] / r[i];
+
+    //! This term numerically unstable for small omega
+    if (cut_off) {
+      A1 = (A1 + Pkbd[i - 1] * weights(i - 1) * gr.drduor(i - 1)) * powk(ratio);
+      A2 = (A2 + Pkbd[i - 1] * weights(i - 1) * gr.drduor(i - 1)) *
+           powk(ratio) * ratio * ratio;
+      C1 = (C1 + Pkbd[i - 1] * weights(i - 1) * r[i - 1] * gr.drdu(i - 1)) *
+           powk(ratio);
+      v1[i] = (A1 - A2 + wsd2 * C1) * du;
+    } else {
+      // first term in first part of v
+      A1 = A1 + jkwr(k - 1, w, r[i - 1]) * Pkbd[i - 1] * weights(i - 1) *
+                  gr.drdu(i - 1);
+
+      // second term in first part of v
+      A2 = (A2 + Pkbd[i - 1] * weights(i - 1) * gr.drduor(i - 1) * 1.0 /
+                   (r[i - 1] * r[i - 1])) *
+           powk(ratio) * ratio * ratio;
+
+      v1[i] = wcubed * ykwr(k + 1, w, r[i]) * A1 + (2.0 * k + 1.0) * A2;
+      v1[i] = -2.0 * odw2 * v1[i] * du;
+    }
+
+    // integral for second term in v
+    A3 = A3 + jkwr(k + 1, w, r[i - 1]) * Qkbd[i - 1] * weights(i - 1) *
+                gr.drdu(i - 1);
+    v2[i] = -2.0 * w * ykwr(k - 1, w, r[i]) * A3 * du;
+  }
+
+  for (std::size_t i = irmax; i < num_points; i++) {
+    v1[i] = 0.0;
+    v2[i] = 0.0;
+  }
+
+  double B1 = 0.0;
+  double B2 = 0.0;
+  double D1 = 0.0;
+  double B3 = 0.0;
+
+  // nb bmax may be num_points
+  const auto bmax = irmax;
+  for (std::size_t i = 0; i <= bmax; i++) {
+    v3[i] = 0.0;
+    v4[i] = 0.0;
+  }
+  const auto rbmax =
+    bmax == num_points ? r.back() + gr.drdu().back() * du : r[bmax];
+
+  // calculating screening functions at end point
+  if (cut_off) {
+    // B1 = Qkbd[bmax - 1] * weights(bmax - 1) * gr.drduor(bmax - 1);
+    // B2 = Qkbd[bmax - 1] * weights(bmax - 1) * gr.drduor(bmax - 1);
+    B1 = Qkbd[bmax - 1];
+    B2 = Qkbd[bmax - 1];
+    D1 = Qkbd[bmax - 1] * weights(bmax - 1) * r[bmax - 1] * gr.drdu(bmax - 1);
+    v3[bmax - 1] = (B1 - B2 + wsd2 * D1) * du;
+  } else {
+    B1 = B1 + ykwr(k + 1, w, r[bmax - 1]) * Qkbd[bmax - 1] * gr.drdu(bmax - 1);
+    B2 = B2 + (pow(r[bmax - 1], k - 1) / pow(r[bmax - 1], k + 2)) *
+                Qkbd[bmax - 1] * gr.drdu(bmax - 1);
+    v3[bmax - 1] = -2.0 * w * jkwr(k - 1, w, r[bmax - 1]) * B1 * du -
+                   2.0 * ((2.0 * k + 1.0) / (w * w)) * B2 * du;
+  }
+
+  B3 = B3 + ykwr(k - 1, w, r[bmax - 1]) * Pkbd[bmax - 1] * gr.drdu(bmax - 1);
+
+  v4[bmax - 1] = -2.0 * w * jkwr(k + 1, w, r[bmax - 1]) * B3 * du;
+
+  for (auto i = bmax - 1; i >= 1; i--) {
+
+    double ratio = r[i - 1] / r[i];
+
+    if (cut_off) {
+      B1 = B1 * powk(ratio) * (1.0 / ratio) +
+           Qkbd[i - 1] * weights(i - 1) * gr.drduor(i - 1);
+      B2 = B2 * powk(ratio) * ratio +
+           Qkbd[i - 1] * weights(i - 1) * gr.drduor(i - 1);
+      D1 = D1 * powk(ratio) * ratio +
+           Qkbd[i - 1] * weights(i - 1) * r[i - 1] * gr.drdu(i - 1);
+      v3[i - 1] = (B1 - B2 + wsd2 * D1) * du;
+    } else {
+      // j_{k-1}(wr1)y_{k+1}(wr2) term in integral that is integrated from r1 <= r2 <=infty
+      B1 = B1 + ykwr(k + 1, w, r[i - 1]) * Qkbd[i - 1] * weights(i - 1) *
+                  gr.drdu(i - 1);
+
+      // r2^{k-1}/r1^{k+2} term in integral that is integrated from r1 <= r2 <=infty
+      B2 = powk(ratio) * (1.0 / ratio) * B2 + Qkbd[i - 1] * weights(i - 1) *
+                                                gr.drduor(i - 1) /
+                                                (r[i - 1] * r[i - 1]);
+
+      v3[i - 1] = wcubed * jkwr(k - 1, w, r[i - 1]) * B1 + (2.0 * k + 1.0) * B2;
+
+      v3[i - 1] = -2.0 * odw2 * v3[i - 1] * du;
+    }
+
+    // j_{k+1}(wr1)y_{k-1}(wr2) term in integral that is integrated from r1 <= r2 <=infty
+    B3 = B3 + ykwr(k - 1, w, r[i - 1]) * Pkbd[i - 1] * weights(i - 1) *
+                gr.drdu(i - 1);
+    v4[i - 1] = -2.0 * w * jkwr(k + 1, w, r[i - 1]) * B3 * du;
+  }
+}
+
+//------------------------------------------------------------------------------
 std::vector<double> yk_ab(const int k, const DiracSpinor &Fa,
                           const DiracSpinor &Fb, const std::size_t maxi) {
   std::vector<double> ykab; //
@@ -291,6 +538,113 @@ void gk_ab(const int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
     yk_ijk_gen_impl<8>(k, fgfg, Fa.grid(), g0, ginf, maxi);
   else
     yk_ijk_gen_impl<-1>(k, fgfg, Fa.grid(), g0, ginf, maxi);
+}
+
+//--------------------------------------------------------------------
+
+// frequency-dependent Breit integrals which i call g^k_{ab}(r,w) and h^k_{ab}(r,w) for X_{ij} and Y_{ij}, respectively
+// also need to define v^{k,1}_{ab} and v^k{k,2}_{ab} for the two respective terms in v^k_{ab} which will be multiplying different parts of the
+void gk_ab_freqw(const int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
+                 std::vector<double> &g0, std::vector<double> &ginf,
+                 const std::size_t maxi, const double w) {
+
+  auto fgfg = [&](std::size_t i) {
+    return (Fa.f(i) * Fb.g(i) + Fa.g(i) * Fb.f(i));
+  };
+
+  if (k == 0)
+    yk_ijk_gen_impl_freq<0>(k, fgfg, Fa.grid(), g0, ginf, maxi, w);
+  else if (k == 1)
+    yk_ijk_gen_impl_freq<1>(k, fgfg, Fa.grid(), g0, ginf, maxi, w);
+  else if (k == 2)
+    yk_ijk_gen_impl_freq<2>(k, fgfg, Fa.grid(), g0, ginf, maxi, w);
+  else if (k == 3)
+    yk_ijk_gen_impl_freq<3>(k, fgfg, Fa.grid(), g0, ginf, maxi, w);
+  else if (k == 4)
+    yk_ijk_gen_impl_freq<4>(k, fgfg, Fa.grid(), g0, ginf, maxi, w);
+  else if (k == 5)
+    yk_ijk_gen_impl_freq<5>(k, fgfg, Fa.grid(), g0, ginf, maxi, w);
+  else if (k == 6)
+    yk_ijk_gen_impl_freq<6>(k, fgfg, Fa.grid(), g0, ginf, maxi, w);
+  else if (k == 7)
+    yk_ijk_gen_impl_freq<7>(k, fgfg, Fa.grid(), g0, ginf, maxi, w);
+  else if (k == 8)
+    yk_ijk_gen_impl_freq<8>(k, fgfg, Fa.grid(), g0, ginf, maxi, w);
+  else
+    yk_ijk_gen_impl_freq<-1>(k, fgfg, Fa.grid(), g0, ginf, maxi, w);
+}
+
+void hk_ab_freqw(const int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
+                 std::vector<double> &b0, std::vector<double> &binf,
+                 std::size_t maxi, const double w) {
+
+  auto fgfg = [&](std::size_t i) {
+    return (Fa.f(i) * Fb.g(i) - Fa.g(i) * Fb.f(i));
+  };
+
+  if (k == 0)
+    yk_ijk_gen_impl_freq<0>(k, fgfg, Fa.grid(), b0, binf, maxi, w);
+  else if (k == 1)
+    yk_ijk_gen_impl_freq<1>(k, fgfg, Fa.grid(), b0, binf, maxi, w);
+  else if (k == 2)
+    yk_ijk_gen_impl_freq<2>(k, fgfg, Fa.grid(), b0, binf, maxi, w);
+  else if (k == 3)
+    yk_ijk_gen_impl_freq<3>(k, fgfg, Fa.grid(), b0, binf, maxi, w);
+  else if (k == 4)
+    yk_ijk_gen_impl_freq<4>(k, fgfg, Fa.grid(), b0, binf, maxi, w);
+  else if (k == 5)
+    yk_ijk_gen_impl_freq<5>(k, fgfg, Fa.grid(), b0, binf, maxi, w);
+  else if (k == 6)
+    yk_ijk_gen_impl_freq<6>(k, fgfg, Fa.grid(), b0, binf, maxi, w);
+  else if (k == 7)
+    yk_ijk_gen_impl_freq<7>(k, fgfg, Fa.grid(), b0, binf, maxi, w);
+  else if (k == 8)
+    yk_ijk_gen_impl_freq<8>(k, fgfg, Fa.grid(), b0, binf, maxi, w);
+  else
+    yk_ijk_gen_impl_freq<-1>(k, fgfg, Fa.grid(), b0, binf, maxi, w);
+}
+
+void vk_ab_freqw(const int k, const DiracSpinor &Fi, const DiracSpinor &Fj,
+                 const Grid &gr, std::vector<double> &v1,
+                 std::vector<double> &v2, std::vector<double> &v3,
+                 std::vector<double> &v4, std::size_t maxi, const double w) {
+
+  auto Xij = [&](std::size_t i) {
+    return (Fi.f(i) * Fj.g(i) + Fi.g(i) * Fj.f(i));
+  };
+
+  auto Yij = [&](std::size_t i) {
+    return (Fi.f(i) * Fj.g(i) - Fi.g(i) * Fj.f(i));
+  };
+
+  std::vector<double> Pkbd(gr.size(), 0.0);
+  std::vector<double> Qkbd(gr.size(), 0.0);
+
+  for (int i = 0; i < gr.size(); i++) {
+    Pkbd[i] = ((Fi.kappa() - Fj.kappa()) / k) * Xij(i) - Yij(i);
+    Qkbd[i] = ((Fi.kappa() - Fj.kappa()) / (k + 1.0)) * Xij(i) + Yij(i);
+  }
+
+  if (k == 0)
+    vkabcd_freqw<0>(k, Pkbd, Qkbd, gr, v1, v2, v3, v4, maxi, w);
+  else if (k == 1)
+    vkabcd_freqw<1>(k, Pkbd, Qkbd, gr, v1, v2, v3, v4, maxi, w);
+  else if (k == 2)
+    vkabcd_freqw<2>(k, Pkbd, Qkbd, gr, v1, v2, v3, v4, maxi, w);
+  else if (k == 3)
+    vkabcd_freqw<3>(k, Pkbd, Qkbd, gr, v1, v2, v3, v4, maxi, w);
+  else if (k == 4)
+    vkabcd_freqw<4>(k, Pkbd, Qkbd, gr, v1, v2, v3, v4, maxi, w);
+  else if (k == 5)
+    vkabcd_freqw<5>(k, Pkbd, Qkbd, gr, v1, v2, v3, v4, maxi, w);
+  else if (k == 6)
+    vkabcd_freqw<6>(k, Pkbd, Qkbd, gr, v1, v2, v3, v4, maxi, w);
+  else if (k == 7)
+    vkabcd_freqw<7>(k, Pkbd, Qkbd, gr, v1, v2, v3, v4, maxi, w);
+  else if (k == 8)
+    vkabcd_freqw<8>(k, Pkbd, Qkbd, gr, v1, v2, v3, v4, maxi, w);
+  else
+    vkabcd_freqw<-1>(k, Pkbd, Qkbd, gr, v1, v2, v3, v4, maxi, w);
 }
 
 //==============================================================================

--- a/src/Coulomb/CoulombIntegrals.hpp
+++ b/src/Coulomb/CoulombIntegrals.hpp
@@ -26,6 +26,22 @@ void gk_ab(const int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
            std::vector<double> &g0, std::vector<double> &ginf,
            const std::size_t maxi = 0);
 
+//! Frequency-dependent Breit g^k_{ab}(r,w) function: (0,r) and (r,inf) part stored sepperately (in/out)
+void gk_ab_freqw(const int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
+                 std::vector<double> &g0, std::vector<double> &ginf,
+                 const std::size_t maxi = 0, const double w = 0.0);
+
+//! Frequency-dependent Breit h^k_{ab}(r,w) function: (0,r) + (r,inf) part stored together (in/out)
+void hk_ab_freqw(const int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
+                 std::vector<double> &g0, std::vector<double> &ginf,
+                 const std::size_t maxi = 0, const double w = 0.0);
+
+//! Frequency-dependent Breit v^k_{ab}(r,w): the first and the second terms are stored separately
+void vk_ab_freqw(const int k, const DiracSpinor &Fi, const DiracSpinor &Fj,
+                 const Grid &gr, std::vector<double> &v1,
+                 std::vector<double> &v2, std::vector<double> &v3,
+                 std::vector<double> &v4, std::size_t maxi, const double w);
+
 //==============================================================================
 
 //! Calculates R^k_abcd for given k. From scratch (calculates y)

--- a/src/HF/Breit.cpp
+++ b/src/HF/Breit.cpp
@@ -27,6 +27,42 @@ DiracSpinor Breit::VbrFa(const DiracSpinor &Fa,
   return BFa;
 }
 
+//================================================
+
+DiracSpinor Breit::VbrFa_freqw(const DiracSpinor &Fa,
+                               const std::vector<DiracSpinor> &core) const {
+  DiracSpinor BFa(Fa.n(), Fa.kappa(), Fa.grid_sptr());
+  for (const auto &Fb : core) {
+    const auto kmin = std::abs(Fb.twoj() - Fa.twoj()) / 2;
+    const auto kmax = (Fb.twoj() + Fa.twoj()) / 2;
+
+    const auto w = PhysConst::alpha * std::abs(Fa.en() - Fb.en());
+
+    // if w is too small then the frequency-dependent integrals diverge, so use the frequency-independent equations instead
+    if (w == 0.0) {
+      for (int k = kmin; k <= kmax; ++k) {
+        const auto s = Angular::neg1pow(k);
+        if (s == 1) {
+          BFa += Bkv_bcd(k, Fa.kappa(), Fb, Fb, Fa);
+        } else {
+          BFa -= Bkv_bcd(k, Fa.kappa(), Fb, Fb, Fa);
+        }
+      }
+    } else {
+      for (int k = kmin; k <= kmax; ++k) {
+        const auto s = Angular::neg1pow(k);
+        if (s == 1) {
+          BFa += Bkv_bcd_freqw(k, Fa.kappa(), Fb, Fb, Fa, w);
+        } else {
+          BFa -= Bkv_bcd_freqw(k, Fa.kappa(), Fb, Fb, Fa, w);
+        }
+      }
+    }
+  }
+  BFa *= (-1.0 / Fa.twojp1());
+  return BFa;
+}
+
 //==============================================================================
 void Breit::fill_gb(const std::vector<DiracSpinor> &basis, int t_max_k) {
 
@@ -158,6 +194,121 @@ DiracSpinor Breit::Bkv_bcd(int k, int kappa_v, const DiracSpinor &Fb,
     for (auto i = Fc.min_pt(); i < Fc.max_pt(); ++i) {
       out.f(i) += factor * gbk.g[i] * Fc.g(i);
       out.g(i) += factor * gbk.g[i] * Fc.f(i);
+    }
+  }
+
+  return out;
+}
+
+// Calculates (m^k(w) + n^k(w) + o^k(w) + p^k(w))Fi(r) -- frequency-dependent Breit
+DiracSpinor Breit::Bkv_bcd_freqw(int k, int kappa_v, const DiracSpinor &Fb,
+                                 const DiracSpinor &Fc, const DiracSpinor &Fd,
+                                 const double w) const {
+
+  // if energy is zero then just use the frequency-independent Breit HF operator to avoid the Bessel functions being called at zero
+  if (w == 0) {
+    return Bkv_bcd(k, kappa_v, Fb, Fc, Fd);
+  }
+
+  DiracSpinor out(0, kappa_v, Fc.grid_sptr());
+  if (k == 0) {
+    out.min_pt() = 0;
+    out.max_pt() = 0;
+    return out;
+  }
+  out.min_pt() = Fc.min_pt();
+  out.max_pt() = Fc.max_pt();
+
+  const auto ka = kappa_v;
+  const auto kb = Fb.kappa();
+  const auto kc = Fc.kappa();
+  const auto kd = Fd.kappa();
+
+  const auto Ckac = Angular::Ck_kk(k, ka, kc);
+  const auto Ckbd = Angular::Ck_kk(k, kb, kd);
+  const auto Dkac = Angular::Ck_kk(k, -ka, kc);
+  const auto Dkbd = Angular::Ck_kk(k, -kb, kd);
+  const auto tja = Angular::twoj_k(ka);
+  const auto sign = Angular::neg1pow_2(2 * k + tja - Fb.twoj());
+
+  const auto have_mop = (Ckac != 0.0) && (Ckbd != 0.0);
+  const auto have_n =
+    (Dkac != 0.0) && (Dkbd != 0.0) && (ka + kc != 0) && (kb + kd != 0);
+
+  // nb: never have both MOP _and_ N ! different parity rule for each k!
+  assert(!(have_mop && have_n));
+
+  if (have_mop) {
+    // Angular factors
+    const auto d_ac = ka - kc;
+    const auto d_bd = kb - kd;
+    const auto d_bd_k = d_bd / double(k);
+    const auto d_bd_kp1 = d_bd / double(k + 1);
+    const auto d_ac_kp1 = d_ac / double(k + 1);
+    const auto d_ac_k = d_ac / double(k);
+
+    // Calculate the frequency-dependent Breit radial screening integrals
+    const auto ghkw = Breit_gh_freqdep::single_k_mop_freq(Fb, Fd, k, w);
+
+    // coeficients (including scaling factors)
+    const auto factor = sign * m_scale * Ckac * Ckbd;
+    const auto c_m1 = m_M * (k + 1) / double(2 * k + 3);
+    const auto c_m2 = m_M * k / double(2 * k - 1);
+    const auto c_o1 =
+      -m_O * (k + 1) * (k + 1) / double((2 * k + 1) * (2 * k + 3));
+    const auto c_o2 = -m_O * k * k / double((2 * k + 1) * (2 * k - 1));
+    const auto c_p0 = -m_P * k * (k + 1) / double(2 * (2 * k + 1));
+
+    // "M1" and "O1" (s/X) part:
+    const auto cf1 = factor * (c_m1 + c_o1) * (d_ac_kp1 + 1.0);
+    const auto cg1 = factor * (c_m1 + c_o1) * (d_ac_kp1 - 1.0);
+    for (auto i = Fc.min_pt(); i < Fc.max_pt(); ++i) {
+      const auto s0 =
+        d_bd_kp1 * (ghkw.g0_plus_freqw[i] + ghkw.gi_plus_freqw[i]) +
+        ghkw.h0_plus_freqw[i] + ghkw.hi_plus_freqw[i];
+      out.f(i) += cf1 * s0 * Fc.g(i);
+      out.g(i) += cg1 * s0 * Fc.f(i);
+    }
+
+    // "M2" and "O2" (t/Y) part:
+    const auto cf2 = factor * (c_m2 + c_o2) * (d_ac_k - 1.0);
+    const auto cg2 = factor * (c_m2 + c_o2) * (d_ac_k + 1.0);
+    for (auto i = Fc.min_pt(); i < Fc.max_pt(); ++i) {
+      const auto t0 =
+        d_bd_k * (ghkw.g0_minus_freqw[i] + ghkw.gi_minus_freqw[i]) -
+        ghkw.h0_minus_freqw[i] - ghkw.hi_minus_freqw[i];
+      out.f(i) += cf2 * t0 * Fc.g(i);
+      out.g(i) += cg2 * t0 * Fc.f(i);
+    }
+
+    //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! THIS TERM IS A PROBLEM !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // "P1" (v/X) part:
+    const auto cf3 = factor * c_p0 * (d_ac_kp1 + 1.0);
+    const auto cg3 = factor * c_p0 * (d_ac_kp1 - 1.0);
+    for (auto i = Fc.min_pt(); i < Fc.max_pt(); ++i) {
+      const auto v1pv4 = ghkw.v1_freqw[i] + ghkw.v4_freqw[i];
+      out.f(i) += cf3 * v1pv4 * Fc.g(i);
+      out.g(i) += cg3 * v1pv4 * Fc.f(i);
+    }
+
+    // "P2" (w/Y) part:
+    const auto cf4 = factor * c_p0 * (d_ac_k - 1.0);
+    const auto cg4 = factor * c_p0 * (d_ac_k + 1.0);
+    for (auto i = Fc.min_pt(); i < Fc.max_pt(); ++i) {
+      const auto v2pv3 = ghkw.v2_freqw[i] + ghkw.v3_freqw[i];
+      out.f(i) += cf4 * v2pv3 * Fc.g(i);
+      out.g(i) += cg4 * v2pv3 * Fc.f(i);
+    }
+  }
+
+  if (have_n && m_N != 0.0) {
+    // "n" part:
+    const auto ghkw = Breit_gh_freqdep::single_k_n_freq(Fb, Fd, k, w);
+    const auto factor = -m_N * (ka + kc) * (kb + kd) / double(k * (k + 1)) *
+                        (sign * m_scale * Dkac * Dkbd);
+    for (auto i = Fc.min_pt(); i < Fc.max_pt(); ++i) {
+      out.f(i) += factor * ghkw.g[i] * Fc.g(i);
+      out.g(i) += factor * ghkw.g[i] * Fc.f(i);
     }
   }
 
@@ -356,6 +507,23 @@ double Breit::BWk_abcd_2(int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
   return Bk_abcd_2(k, Fa, Fb, Fc, Fd) + BPk_abcd_2(k, Fa, Fb, Fc, Fd);
 }
 
+// calculates two-particle Breit matrix element evaluated at the energy difference of electrons a and c
+double Breit::Bk_abcd_eac_freqw(int k, const DiracSpinor &Fa,
+                                const DiracSpinor &Fb, const DiracSpinor &Fc,
+                                const DiracSpinor &Fd) const {
+
+  return Fa * Bkv_bcd_freqw(k, Fa.kappa(), Fb, Fc, Fd,
+                            PhysConst::alpha * abs(Fa.en() - Fc.en()));
+}
+
+// calculates two-particle Breit matrix element evaluated at the energy difference of electrons b and d
+double Breit::Bk_abcd_ebd_freqw(int k, const DiracSpinor &Fa,
+                                const DiracSpinor &Fb, const DiracSpinor &Fc,
+                                const DiracSpinor &Fd) const {
+  return Fa * Bkv_bcd_freqw(k, Fa.kappa(), Fb, Fc, Fd,
+                            PhysConst::alpha * abs(Fb.en() - Fd.en()));
+}
+
 //==============================================================================
 DiracSpinor Breit::dV_Br(int kappa, int K, const DiracSpinor &Fa,
                          const DiracSpinor &Fb, const DiracSpinor &Xbeta,
@@ -461,5 +629,55 @@ void single_k_n::calculate(const DiracSpinor &Fi, const DiracSpinor &Fj,
 }
 
 } // namespace Breit_gb
+
+namespace Breit_gh_freqdep {
+// generates frequency-dependent Breit screening functions for calculating m, o, p
+void single_k_mop_freq::calculate(const DiracSpinor &Fi, const DiracSpinor &Fj,
+                                  int k, const double w) {
+
+  if (!Angular::Ck_kk_SR(k, Fi.kappa(), Fj.kappa()))
+    return;
+
+  const auto maxi =
+    std::min({Fi.max_pt(), Fj.max_pt(), Fi.grid().num_points()}); // ok?
+
+  // g^{k+1}(w), g^{k-1}(w), h^{k+1}(w), h^{k-1}(w) used in m, o, p
+  assert(k != 0);
+
+  const auto r = Fi.grid().r();
+
+// calculates
+#pragma omp parallel sections num_threads(4)
+  {
+#pragma omp section
+    Coulomb::gk_ab_freqw(k - 1, Fi, Fj, g0_minus_freqw, gi_minus_freqw, maxi,
+                         w);
+#pragma omp section
+    Coulomb::hk_ab_freqw(k - 1, Fi, Fj, h0_minus_freqw, hi_minus_freqw, maxi,
+                         w);
+#pragma omp section
+    Coulomb::gk_ab_freqw(k + 1, Fi, Fj, g0_plus_freqw, gi_plus_freqw, maxi, w);
+#pragma omp section
+    Coulomb::hk_ab_freqw(k + 1, Fi, Fj, h0_plus_freqw, hi_plus_freqw, maxi, w);
+#pragma omp section
+    Coulomb::vk_ab_freqw(k, Fi, Fj, Fi.grid(), v1_freqw, v2_freqw, v3_freqw,
+                         v4_freqw, maxi, w);
+  }
+}
+
+// constructs full g^k - only used for calculating u^k_{abcd} and then from there n^k_{abcd}
+void single_k_n_freq::calculate(const DiracSpinor &Fi, const DiracSpinor &Fj,
+                                int k, const double w) {
+  if (!Angular::Ck_kk_SR(k, -Fi.kappa(), Fj.kappa()))
+    return;
+  const auto maxi =
+    std::min({Fi.max_pt(), Fj.max_pt(), Fi.grid().num_points()}); // ok?
+  assert(k != 0);
+  Coulomb::gk_ab_freqw(k, Fi, Fj, g, gi, maxi, w);
+  using namespace qip::overloads;
+  g += gi;
+}
+
+} // namespace Breit_gh_freqdep
 
 } // namespace HF

--- a/src/HF/Breit.hpp
+++ b/src/HF/Breit.hpp
@@ -47,6 +47,45 @@ private:
 
 } // namespace Breit_gb
 
+namespace Breit_gh_freqdep {
+
+struct single_k_mop_freq {
+  // Class to hold the frequency-dependent Breit-Coulomb integrals, for single k
+public:
+  single_k_mop_freq() {}
+  single_k_mop_freq(const DiracSpinor &Fi, const DiracSpinor &Fj, int k,
+                    const double w) {
+    calculate(Fi, Fj, k, w);
+  }
+
+  void calculate(const DiracSpinor &Fi, const DiracSpinor &Fj, int k,
+                 const double w);
+  std::vector<double> g0_minus_freqw{}, gi_minus_freqw{};
+  std::vector<double> g0_plus_freqw{}, gi_plus_freqw{};
+  std::vector<double> h0_minus_freqw{}, hi_minus_freqw{};
+  std::vector<double> h0_plus_freqw{}, hi_plus_freqw{};
+  std::vector<double> v1_freqw{}, v2_freqw{}, v3_freqw{}, v4_freqw{};
+};
+
+struct single_k_n_freq {
+  // Class to hold the Breit-Coulomb integrals, for single k
+public:
+  single_k_n_freq() {}
+  single_k_n_freq(const DiracSpinor &Fi, const DiracSpinor &Fj, int k,
+                  const double w) {
+    calculate(Fi, Fj, k, w);
+  }
+
+  void calculate(const DiracSpinor &Fi, const DiracSpinor &Fj, int k,
+                 const double w);
+  std::vector<double> g{};
+
+private:
+  std::vector<double> gi{};
+};
+
+} // namespace Breit_gh_freqdep
+
 //==============================================================================
 //! Breit (Hartree-Fock Breit) interaction potential
 class Breit {
@@ -113,6 +152,10 @@ public:
   DiracSpinor VbrFa(const DiracSpinor &Fa,
                     const std::vector<DiracSpinor> &core) const;
 
+  //! (hopefully) calculates VBr(w)Fa for frequency-dependent Breit
+  DiracSpinor VbrFa_freqw(const DiracSpinor &Fa,
+                          const std::vector<DiracSpinor> &core) const;
+
   //! dV_b*Fa, dV_b is the RPA correction arising due to Fb -> Fb + dFb
   //! @details
   //! K is multipolarity of RPA operator, Fb is core state, with Xbeta and Ybeta
@@ -124,6 +167,14 @@ public:
   //! Reduced Breit integral (analogue of Coulomb Q^k).
   double Bk_abcd(int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
                  const DiracSpinor &Fc, const DiracSpinor &Fd) const;
+
+  //! Reduced frequency-dependent Breit integral evaluated at energy, Ea - Ec
+  double Bk_abcd_eac_freqw(int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
+                           const DiracSpinor &Fc, const DiracSpinor &Fd) const;
+
+  //! Reduced frequency-dependent Breit integral evaluated at energy, Eb - Ed
+  double Bk_abcd_ebd_freqw(int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
+                           const DiracSpinor &Fc, const DiracSpinor &Fd) const;
 
   //! Reduced exchange Breit integral (analogue of Coulomb P^k).
   double BPk_abcd(int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
@@ -137,6 +188,13 @@ public:
   //! Bkv_bcd defined: B^k_abcd = <a|Bkv_bcd> (direct part)
   DiracSpinor Bkv_bcd(int k, int kappa_v, const DiracSpinor &Fb,
                       const DiracSpinor &Fc, const DiracSpinor &Fd) const;
+  // Calculates (m^k(w) + n^k(w) + o^k(w) + p^k(w))Fi(r) -- frequency-dependent Breit
+  DiracSpinor Bkv_bcd_freqw(int k, int kappa_v, const DiracSpinor &Fb,
+                            const DiracSpinor &Fc, const DiracSpinor &Fd,
+                            const double w) const;
+
+  //!Should add two-body matrix elements for frequency-dependent Breit at some point. As well as writing function for direct contribution to HF
+
   //! BPkv_bcd defined: P(B)^k_abcd = <a|BPkv_bcd> (exchange part)
   DiracSpinor BPkv_bcd(int k, int kappa_v, const DiracSpinor &Fb,
                        const DiracSpinor &Fc, const DiracSpinor &Fd) const;

--- a/src/HF/HartreeFock.cpp
+++ b/src/HF/HartreeFock.cpp
@@ -72,7 +72,8 @@ HartreeFock::HartreeFock(std::shared_ptr<const Grid> grid,
                          std::vector<DiracSpinor> core,
                          std::optional<QED::RadPot> vrad, double alpha,
                          Method method, double x_Breit, double in_eps,
-                         Parametric::Type potential, double H_g, double d_t)
+                         Parametric::Type potential, double H_g, double d_t,
+                         bool freqBreit)
   : m_rgrid(grid),
     m_core(std::move(core)),
     m_vnuc(std::move(vnuc)),
@@ -82,6 +83,7 @@ HartreeFock::HartreeFock(std::shared_ptr<const Grid> grid,
     m_alpha(alpha),
     m_method(method),
     m_eps_HF(std::abs(in_eps) < 1.0 ? in_eps : std::pow(10, -in_eps)),
+    m_freqBreit(freqBreit),
     m_vdir(m_rgrid->num_points(), 0.0),
     m_Yab() {
   set_parametric_potential(true, potential, H_g, d_t);
@@ -467,9 +469,15 @@ EpsIts HartreeFock::hartree_fock_core() {
 
       if (m_VBr) {
         // Add Breit to v_nonlocal, and energy guess
-        const auto VbrFa = m_VBr->VbrFa(Fa, core_prev);
-        en += (Fzero * VbrFa) / (Fa * Fzero);
-        v_nonlocal += VbrFa;
+        if (m_freqBreit == true) {
+          const auto VbrFa = m_VBr->VbrFa_freqw(Fa, core_prev);
+          en += (Fzero * VbrFa) / (Fa * Fzero);
+          v_nonlocal += VbrFa;
+        } else {
+          const auto VbrFa = m_VBr->VbrFa(Fa, core_prev);
+          en += (Fzero * VbrFa) / (Fa * Fzero);
+          v_nonlocal += VbrFa;
+        }
       }
 
       // Solve HF Dirac equation for core state
@@ -578,7 +586,11 @@ EpsIts HartreeFock::hf_valence(DiracSpinor &Fa,
 
     auto VxFa = vexFa(Fa);
     if (m_VBr) {
-      VxFa += m_VBr->VbrFa(Fa, m_core);
+      if (m_freqBreit == true) {
+        VxFa += m_VBr->VbrFa_freqw(Fa, m_core);
+      } else {
+        VxFa += m_VBr->VbrFa(Fa, m_core);
+      }
     }
     if (Sigma) {
       const auto f = prev_its && it < 15 ? it / 15.0 : 1.0;
@@ -1161,7 +1173,11 @@ void HartreeFock::hf_orbital_green(
     {
       auto VnlF_tilde = ::HF::vexFa(dFa, static_core, k_max);
       if (tVBr)
-        VnlF_tilde += tVBr->VbrFa(dFa, static_core);
+        if (m_freqBreit == true) {
+          VnlF_tilde += tVBr->VbrFa_freqw(dFa, static_core);
+        } else {
+          VnlF_tilde += tVBr->VbrFa(dFa, static_core);
+        }
       if (Sigma)
         VnlF_tilde += (*Sigma)(dFa);
       if (!dv0.empty())

--- a/src/HF/HartreeFock.hpp
+++ b/src/HF/HartreeFock.hpp
@@ -79,6 +79,7 @@ private:
   double m_alpha;
   Method m_method;
   double m_eps_HF;
+  bool m_freqBreit;
   std::vector<double> m_vdir;
   Coulomb::YkTable m_Yab;
   int m_max_hf_its = 128;
@@ -114,7 +115,7 @@ public:
               Method method = Method::HartreeFock, double x_Breit = 0.0,
               double eps_HF = 0.0,
               Parametric::Type potential = Parametric::Type::Green,
-              double H_g = 0.0, double d_t = 0.0);
+              double H_g = 0.0, double d_t = 0.0, bool freqBreit = false);
 
   //! Solves HF equations self-consitantly for core orbs. Returns epsilon.
   EpsIts solve_core(bool print = true);

--- a/src/Maths/SphericalBessel.hpp
+++ b/src/Maths/SphericalBessel.hpp
@@ -75,6 +75,208 @@ T exactGSL_JL(int L, T x) {
   return (T)gsl_sf_bessel_jl(L, (double)x);
 }
 
+//! Used for frequency-dependent Breit - more generic formula that can be used to evaluate spherical Bessel function of first kind for negative orders
+template <typename T>
+T exactGSL_JL_alt(int L, T x) {
+
+  // Very low x expansion [keeps terms up to order (wr)^8]
+  if (std::abs(x) < (T)1.0e-8) {
+    if (L == 0)
+      return 1.0;
+    else
+      return 0.0;
+  }
+
+  // series expansion for small wr [keeps every term up to order (wr)^8]
+  if (std::fabs(x) < 0.5) {
+    if (L == 0) {
+      return 1.0 - 0.166666667 * (x * x) + 0.00833333333 * qip::pow<4>(x) -
+             0.000198412698 * qip::pow<6>(x) +
+             0.00000275573192 * qip::pow<8>(x);
+    }
+    if (L == 1) {
+      return 0.333333333 * x - 0.0333333333 * (x * x * x) +
+             0.00119047619 * qip::pow<5>(x) - 0.0000220458553 * qip::pow<7>(x);
+    }
+    if (L == 2) {
+      return 0.0666666667 * (x * x) - 0.00476190476 * qip::pow<4>(x) +
+             0.000132275132 * qip::pow<6>(x) -
+             0.00000200416867 * qip::pow<8>(x);
+    }
+    if (L == 3) {
+      return 0.00952380952 * (x * x * x) - 0.000529100529 * qip::pow<5>(x) +
+             0.0000120250120 * qip::pow<7>(x);
+    }
+    if (L == 4) {
+      return 0.00105820105 * qip::pow<4>(x) - 0.0000481000481 * qip::pow<6>(x) +
+             0.000000925000925 * qip::pow<8>(x);
+    }
+    if (L == 5) {
+      return 0.0000962000962 * qip::pow<5>(x) -
+             0.0000037000037 * qip::pow<7>(x);
+    }
+    if (L == 6) {
+      return 0.0000074000074 * qip::pow<6>(x) -
+             0.00000024666913 * qip::pow<8>(x);
+    }
+    if (L == 7) {
+      return 0.000000493333826 * qip::pow<7>(x);
+    }
+  }
+
+  // Explicit formulas for first few L's
+  if (L == 0) {
+    return std::sin(x) / x;
+  }
+  if (L == 1) {
+    return std::sin(x) / (x * x) - std::cos(x) / x;
+  }
+  if (L == 2) {
+    return (3.0 / (x * x) - 1.0) * std::sin(x) / x -
+           3.0 * std::cos(x) / (x * x);
+  }
+  if (L == 3) {
+    return (15.0 / (x * x * x) - 6.0 / x) * std::sin(x) / x -
+           (15.0 / (x * x) - 1.0) * std::cos(x) / x;
+  }
+  if (L == 4) {
+    return 5.0 * (-21.0 + 2.0 * x * x) * std::cos(x) / qip::pow<4>(x) +
+           (105.0 - 45.0 * x * x + qip::pow<4>(x)) * std::sin(x) /
+             (qip::pow<5>(x));
+  }
+  if (L == 5) {
+    return (105.0 * x * x - 945.0 - qip::pow<4>(x)) * std::cos(x) /
+             qip::pow<5>(x) +
+           15.0 * (63.0 - 28.0 * x * x + qip::pow<4>(x)) * std::sin(x) /
+             qip::pow<6>(x);
+  }
+  if (L == 6) {
+    return (10395.0 - qip::pow<6>(x) - 4725.0 * x * x +
+            210.0 * qip::pow<4>(x)) *
+             std::sin(x) / qip::pow<7>(x) +
+           21.0 * (60.0 * x * x - 495.0 - qip::pow<4>(x)) * std::cos(x) /
+             qip::pow<6>(x);
+  }
+  if (L == 7) {
+    return 7.0 *
+             (19305.0 - 4.0 * qip::pow<6>(x) - 8910.0 * x * x +
+              450.0 * qip::pow<4>(x)) *
+             std::sin(x) / qip::pow<8>(x) +
+           (qip::pow<6>(x) + 17325.0 * x * x - 378.0 * qip::pow<4>(x) -
+            135135.0) *
+             std::cos(x) / qip::pow<7>(x);
+  }
+
+  return (T)(sqrt(M_PI / (2.0 * x)) *
+             gsl_sf_bessel_Jnu(L + 1.0 / 2, (double)x));
+}
+
+//! Spherical Bessel functions of second kind
+template <typename T>
+T exactGSL_YL(int L, T x) {
+  return (T)gsl_sf_bessel_yl(L, (double)x);
+}
+
+//! Used for frequency-dependent Breit - more generic formula that can be used to evaluate spherical Bessel function of second kind for negative orders
+template <typename T>
+T exactGSL_YL_alt(int L, T x) {
+
+  // series expansion for small wr [keeps every term up to order (wr)^8]
+  if (std::fabs(x) < 0.1) {
+    if (L == 0) {
+      return -1.0 / x + 0.5 * x - 0.0416666667 * (x * x * x) +
+             0.00138888888 * qip::pow<5>(x) - 0.0000248015873 * qip::pow<7>(x);
+    }
+    if (L == 1) {
+      return -1.0 / (x * x) - 0.5 + 0.125 * (x * x) -
+             0.00694444444 * qip::pow<4>(x) + 0.000173611111 * qip::pow<6>(x) -
+             0.00000248015873 * qip::pow<8>(x);
+    }
+    if (L == 2) {
+      return -3.0 / (x * x * x) - 0.5 / x - 0.125 * x +
+             0.0208333333 * (x * x * x) - 0.000868055555 * qip::pow<5>(x) +
+             0.0000173611111 * qip::pow<7>(x);
+    }
+    if (L == 3) {
+      return -15.0 / (qip::pow<4>(x)) - 1.5 / (x * x) - 0.125 -
+             0.0208333333 * x * x + 0.00260416666 * qip::pow<4>(x) -
+             0.0000868055555 * qip::pow<6>(x) +
+             0.00000144675925 * qip::pow<8>(x);
+    }
+    if (L == 4) {
+      return -105.0 / (qip::pow<5>(x)) - 7.5 / (x * x * x) - 0.375 / x -
+             0.0208333333 * x - 0.00260416666 * (x * x * x) +
+             0.000260416666 * qip::pow<5>(x) -
+             0.00000723379629 * qip::pow<7>(x);
+    }
+    if (L == 5) {
+      return -945.0 / (qip::pow<6>(x)) - 52.5 / (qip::pow<4>(x)) -
+             1.875 / (x * x) - 0.0625 - 0.00260416666 * x * x -
+             0.000260416666 * qip::pow<4>(x) +
+             0.0000217013888 * qip::pow<6>(x) -
+             0.000000516699735 * qip::pow<8>(x);
+    }
+    if (L == 6) {
+      return -10395.0 / (qip::pow<7>(x)) - 472.5 / (qip::pow<5>(x)) -
+             13.125 / (x * x * x) - 0.3125 / x - 0.0078125 * x -
+             0.000260416666 * (x * x * x) - 0.0000217013888 * qip::pow<5>(x) +
+             0.0000015500992 * qip::pow<7>(x);
+    }
+    if (L == 7) {
+      -135135.0 / qip::pow<8>(x) - 5197.5 / qip::pow<6>(x) -
+        118.125 / qip::pow<4>(x) - 2.1875 / (x * x) - 0.0390625 -
+        0.00078125 * x *x - 0.0000217013888 * qip::pow<4>(x) -
+        0.00000155009920 * qip::pow<6>(x) + 0.0000000968812004 * qip::pow<8>(x);
+    }
+  }
+
+  // Explicit formulas for first few L's
+  if (L == 0) {
+    return -std::cos(x) / x;
+  }
+  if (L == 1) {
+    return -std::cos(x) / (x * x) - std::sin(x) / x;
+  }
+  if (L == 2) {
+    return (1.0 - 3.0 / (x * x)) * std::cos(x) / x -
+           3.0 * std::sin(x) / (x * x);
+  }
+  if (L == 3) {
+    return (6.0 / x - 15.0 / (x * x * x)) * std::cos(x) / x -
+           (15.0 / (x * x) - 1.0) * std::sin(x) / x;
+  }
+  if (L == 4) {
+    return 5.0 * (-21.0 + 2.0 * x * x) * std::sin(x) / qip::pow<4>(x) +
+           (45.0 * x * x - 105.0 - qip::pow<4>(x)) * std::cos(x) /
+             (qip::pow<5>(x));
+  }
+  if (L == 5) {
+    return 15.0 * (28.0 * x * x - qip::pow<4>(x) - 63.0) * std::cos(x) /
+             qip::pow<6>(x) +
+           (105.0 * x * x - qip::pow<4>(x) - 945.0) * std::sin(x) /
+             qip::pow<5>(x);
+  }
+  if (L == 6) {
+    return (qip::pow<6>(x) - 10395.0 + 4725.0 * x * x -
+            210.0 * qip::pow<4>(x)) *
+             std::cos(x) / qip::pow<7>(x) +
+           21.0 * (60.0 * x * x - 495.0 - qip::pow<4>(x)) * std::sin(x) /
+             qip::pow<6>(x);
+  }
+  if (L == 7) {
+    return 7.0 *
+             (4.0 * qip::pow<6>(x) + 8910.0 * x * x - 450.0 * qip::pow<4>(x) -
+              19305.0) *
+             std::cos(x) / qip::pow<8>(x) +
+           (qip::pow<6>(x) + 17325.0 * x * x - 378.0 * qip::pow<4>(x) -
+            135135.0) *
+             std::sin(x) / qip::pow<7>(x);
+  }
+
+  return (T)(sqrt(M_PI / (2.0 * x)) *
+             gsl_sf_bessel_Ynu(L + 1.0 / 2, (double)x));
+}
+
 //==============================================================================
 //! Creates a vector of Jl(r) for given r
 template <typename T>

--- a/src/Wavefunction/Wavefunction.cpp
+++ b/src/Wavefunction/Wavefunction.cpp
@@ -120,14 +120,15 @@ Wavefunction::determineCore(const std::string &str_core_in)
 
 //==============================================================================
 void Wavefunction::set_HF(const std::string &method, const double x_Breit,
-                          const std::string &in_core, double eps_HF,
-                          bool print) {
+                          const std::string &in_core, double eps_HF, bool print,
+                          bool freq_Breit) {
 
   auto core = determineCore(in_core);
   const auto qed = std::nullopt; // we add QED (optionally) later - to allow for
                                  // QED into valence, but not core
   m_HF = HF::HartreeFock(rgrid, m_vnuc, std::move(core), qed, m_alpha,
-                         HF::parseMethod(method), x_Breit, eps_HF);
+                         HF::parseMethod(method), x_Breit, eps_HF,
+                         Parametric::Type::Green, 0.0, 0.0, freq_Breit);
 
   // Move this into HF?
   if (print) {
@@ -150,7 +151,10 @@ void Wavefunction::set_HF(const std::string &method, const double x_Breit,
     }
 
     // Can only include Breit within HF
-    if (method == "HartreeFock" && x_Breit != 0.0) {
+    if (method == "HartreeFock" && x_Breit != 0.0 && freq_Breit == true) {
+      std::cout
+        << "Including frequency-dependent Breit\n"; // scale for frequency-dependent Breit?
+    } else if (method == "HartreeFock" && x_Breit != 0.0) {
       std::cout << "Including Breit (scale = " << x_Breit << ")\n";
     } else if (method != "HartreeFock" && x_Breit != 0.0) {
       fmt2::styled_print(fg(fmt::color::orange), "\nWARNING\n");

--- a/src/Wavefunction/Wavefunction.hpp
+++ b/src/Wavefunction/Wavefunction.hpp
@@ -240,7 +240,8 @@ public:
   //! equations)
   void set_HF(const std::string &method = "HartreeFock",
               const double x_Breit = 0.0, const std::string &in_core = "",
-              double eps_HF = 1.0e-13, bool print = true);
+              double eps_HF = 1.0e-13, bool print = true,
+              bool freq_Breit = false);
 
   //! Performs hartree-Fock procedure for core
   void solve_core(bool print = true);

--- a/src/ampsci/ampsci.cpp
+++ b/src/ampsci/ampsci.cpp
@@ -159,6 +159,7 @@ Wavefunction ampsci(const IO::InputBlock &input) {
      {"Breit", "Include Breit into HF? true/false, or scale factor. Scale "
                "factor for Breit Hamiltonian is usially 0.0 (no "
                "Breit) or 1.0 (full Breit), but can take any value. [false]"},
+     {"FrequencyBreit", "Include frequency-dependent Breit into HF?. [false]"},
      {"QED",
       "Include QED? Three options: true, false, valence. If 'valence, will "
       "include QED only into valence states, but not the core. Detailed QED "
@@ -173,6 +174,7 @@ Wavefunction ampsci(const IO::InputBlock &input) {
   const auto x_Breit =
     tf_Breit ? 1.0 : input.get({"HartreeFock"}, "Breit", 0.0);
   const auto valence = input.get({"HartreeFock"}, "valence", ""s);
+  const auto freq_Breit = input.get({"HartreeFock"}, "FrequencyBreit", false);
 
   // Decide if to include QED into core+valence, just core, or not at all
   const auto qed_input = input.getBlock("RadPot");
@@ -187,7 +189,7 @@ Wavefunction ampsci(const IO::InputBlock &input) {
 
   // Set up the Hartree Fock potential/method (does not solve)
   // (Must set HF before adding RadPot - but must add RadPot before solving HF)
-  wf.set_HF(HF_method, x_Breit, core, eps_HF, true);
+  wf.set_HF(HF_method, x_Breit, core, eps_HF, true, freq_Breit);
 
   // Forms QED radiative potential, if RadPot{} block is present.
   // Note: input options are parsed inside radiativePotential()


### PR DESCRIPTION
Could be sped up in certain places like with the constant call to Bessel functions inside the radial integrals. Also maybe the radial integrals could be sped up with the ordering of the if statements and for loops.