### PR TITLE
Frequency-dependent Breit into CI and screening into CI Sigma^2

### DIFF
--- a/src/CI/CI.tests.cpp
+++ b/src/CI/CI.tests.cpp
@@ -73,3 +73,48 @@ TEST_CASE("CI: Configuration Interaction, unit tests", "[CI][unit]") {
   REQUIRE(CI::Term_Symbol(1, 2, 1, -1) == "2^D°_1/2");
   REQUIRE(CI::Term_Symbol(6, 0, 0, 1) == "1^S_3");
 }
+
+// test for the efficiency of function that fills the Pi matrix
+TEST_CASE("CI: Constructing Pi matrix test", "[CI][unit][k78]") {
+  Wavefunction wf({400, 1.0e-4, 45.0, 0.33 * 20.0, "loglinear"},
+                  {"Ba", -1, "pointlike"}, 1.0);
+  wf.solve_core("HartreeFock", std::nullopt, "[Xe]", 1.0e-5);
+  wf.formBasis(
+    SplineBasis::Parameters("30spdfghi", 45, 7, 1.0e-2, 1.0e-4, 50.0));
+
+  const std::size_t i0 = 0;
+  const std::size_t num_points = wf.grid().num_points();
+  const std::size_t num_points_subgrid =
+    num_points / 4; // stride in denominator
+  const std::size_t stride = num_points / num_points_subgrid;
+
+  MBPT::Feynman feyn = MBPT::Feynman(wf.vHF(), i0, stride, num_points_subgrid,
+                                     {}, 1, true, true, false);
+
+  const std::string cis2_basis_string = "12spdf";
+  const std::vector<DiracSpinor> cis2_basis =
+    CI::basis_subset(wf.basis(), cis2_basis_string, wf.coreConfiguration());
+  int max_k_Coulomb = 7;
+
+  // extract list of kappa from S^2 basis
+  const auto kappai_list = AtomData::kappa_index_list(cis2_basis_string);
+
+  std::chrono::steady_clock::time_point begin =
+    std::chrono::steady_clock::now();
+
+  std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> PiMatrix(
+    max_k_Coulomb,
+    {kappai_list.size(), kappai_list.size(),
+     MBPT::ComplexRMatrix{i0, stride, num_points_subgrid, wf.grid_sptr()}});
+
+  MBPT::FillPiMatrix(max_k_Coulomb, cis2_basis, cis2_basis_string, kappai_list,
+                     feyn, PiMatrix);
+
+  std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+
+  std::cout
+    << std::endl
+    << std::endl
+    << "Time taken to form and fill Pi matrix: "
+    << std::chrono::duration_cast<std::chrono::minutes>(end - begin).count();
+}

--- a/src/CI/CI_Integrals.cpp
+++ b/src/CI/CI_Integrals.cpp
@@ -6,6 +6,7 @@
 #include "MBPT/CorrelationPotential.hpp"
 #include "MBPT/Sigma2.hpp"
 #include "Wavefunction/DiracSpinor.hpp"
+#include "Wavefunction/Wavefunction.hpp"
 #include <vector>
 
 namespace CI {
@@ -231,7 +232,8 @@ Coulomb::meTable<double>
 calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
                    const std::vector<DiracSpinor> &s1_basis_core,
                    const std::vector<DiracSpinor> &s1_basis_excited,
-                   const Coulomb::QkTable &qk, bool include_Sigma1) {
+                   const Coulomb::QkTable &qk, bool include_Sigma1,
+                   const Wavefunction &wf) {
   // Create lookup table for one-particle matrix elements, h1
   Coulomb::meTable<double> h1;
 
@@ -249,7 +251,11 @@ calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
         continue;
       if (w.kappa() != v.kappa())
         continue;
-      const auto h0_vw = v == w ? v.en() : 0.0;
+      // const auto h0_vw = v == w ? v.en() : 0.0;
+
+      // if we have frequency-dependent Breit, no longer have eigenstates of
+      // h1, so need to directly evaluate <w|h1|v>
+      const auto h0_vw = wf.Hab(v, w);
 
       // Can use Sigma matrix instead: all-orders?
       const auto Sigma_vw =
@@ -284,7 +290,11 @@ calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
         continue;
       if (w.kappa() != v.kappa())
         continue;
-      const auto h0_vw = v == w ? v.en() : 0.0;
+      // const auto h0_vw = v == w ? v.en() : 0.0;
+
+      // if we have frequency-dependent Breit, no longer have eigenstates of
+      // h1, so need to directly evaluate <w|h1|v>
+      const auto h0_vw = v * w;
 
       // Can use Sigma matrix instead: all-orders?
       const auto Sigma_vw = include_Sigma1 ? v * Sigma_w : 0.0;
@@ -311,17 +321,30 @@ Coulomb::WkTable calculate_Bk(const std::string &bk_filename,
 
   if (!no_new_integrals) {
 
-    auto vBr = *pBr;              // copy, so we can fill two-particle 'bk'
-    vBr.fill_gb(ci_basis, max_k); // very quick, and makes below *much* faster
-    //* nb: uses HUGE memory if basis is large; CI basis normally small enough
+    auto vBr = *pBr; // copy, so we can fill two-particle 'bk'
 
-    const auto Bk_function = [&](int k, const DiracSpinor &v,
-                                 const DiracSpinor &w, const DiracSpinor &x,
-                                 const DiracSpinor &y) {
-      return vBr.Bk_abcd_2(k, v, w, x, y);
-    };
+    // if frequency-independent Breit, can pre-fill Breit radial integrals
+    if (vBr.lambda_f() == 0.0) {
+      vBr.fill_gb(ci_basis, max_k); // very quick, and makes below *much* faster
+      //* nb: uses HUGE memory if basis is large; CI basis normally small enough
 
-    Bk.fill(ci_basis, Bk_function, HF::Breit::Bk_SR, max_k, false);
+      const auto Bk_function = [&](int k, const DiracSpinor &v,
+                                   const DiracSpinor &w, const DiracSpinor &x,
+                                   const DiracSpinor &y) {
+        return vBr.Bk_abcd_2(k, v, w, x, y);
+      };
+
+      Bk.fill(ci_basis, Bk_function, HF::Breit::Bk_SR, max_k, false);
+
+    } else {
+      const auto Bk_function = [&](int k, const DiracSpinor &v,
+                                   const DiracSpinor &w, const DiracSpinor &x,
+                                   const DiracSpinor &y) {
+        return vBr.Bk_abcd_freqw(k, v, w, x, y);
+      };
+
+      Bk.fill(ci_basis, Bk_function, HF::Breit::Bk_SR, max_k, false);
+    }
 
     // print summary
     Bk.summary();

--- a/src/CI/CI_Integrals.cpp
+++ b/src/CI/CI_Integrals.cpp
@@ -251,22 +251,26 @@ calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
         continue;
       if (w.kappa() != v.kappa())
         continue;
-      // const auto h0_vw = v == w ? v.en() : 0.0;
+      const auto h0_vw = v == w ? v.en() : 0.0;
 
       // if we have frequency-dependent Breit, no longer have eigenstates of
       // h1, so need to directly evaluate <w|h1|v>
-      const auto h0_vw = wf.Hab(v, w);
+      // const auto h0_vw = wf.Hab(v, w);
 
       // Can use Sigma matrix instead: all-orders?
       const auto Sigma_vw =
+        wf.Sigma() ?
+          0.0 :
         include_Sigma1 ?
           MBPT::Sigma_vw(v, w, qk, s1_basis_core, s1_basis_excited, 99, ev) :
           0.0;
 
       h1.add(v, w, h0_vw + Sigma_vw);
+      // h1.add(v, w, h0_vw);
       // Add symmetric partner:
       if (v != w)
         h1.add(w, v, h0_vw + Sigma_vw);
+      // h1.add(w, v, h0_vw);
     }
   }
   return h1;
@@ -296,8 +300,11 @@ calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
       // h1, so need to directly evaluate <w|h1|v>
       const auto h0_vw = wf.Hab(v, w);
 
+      //!!!!!! don't need this if we have Sigma as Hab(v, w) already includes Sigma if it exists
       // Can use Sigma matrix instead: all-orders?
-      const auto Sigma_vw = include_Sigma1 ? v * Sigma_w : 0.0;
+      const auto Sigma_vw = wf.Sigma()     ? 0.0 :
+                            include_Sigma1 ? v * Sigma_w :
+                                             0.0;
 
       h1.add(v, w, h0_vw + Sigma_vw);
       // Add symmetric partner:

--- a/src/CI/CI_Integrals.cpp
+++ b/src/CI/CI_Integrals.cpp
@@ -275,8 +275,8 @@ calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
 //==============================================================================
 Coulomb::meTable<double>
 calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
-                   const MBPT::CorrelationPotential &Sigma,
-                   bool include_Sigma1) {
+                   const MBPT::CorrelationPotential &Sigma, bool include_Sigma1,
+                   const Wavefunction &wf) {
   // Create lookup table for one-particle matrix elements, h1
   Coulomb::meTable<double> h1;
 
@@ -294,7 +294,7 @@ calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
 
       // if we have frequency-dependent Breit, no longer have eigenstates of
       // h1, so need to directly evaluate <w|h1|v>
-      const auto h0_vw = v * w;
+      const auto h0_vw = wf.Hab(v, w);
 
       // Can use Sigma matrix instead: all-orders?
       const auto Sigma_vw = include_Sigma1 ? v * Sigma_w : 0.0;

--- a/src/CI/CI_Integrals.cpp
+++ b/src/CI/CI_Integrals.cpp
@@ -251,13 +251,14 @@ calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
         continue;
       if (w.kappa() != v.kappa())
         continue;
-      const auto h0_vw = v == w ? v.en() : 0.0;
+      // const auto h0_vw = v == w ? v.en() : 0.0;
 
       // if we have frequency-dependent Breit, no longer have eigenstates of
       // h1, so need to directly evaluate <w|h1|v>
-      // const auto h0_vw = wf.Hab(v, w);
+      const auto h0_vw = wf.Hab(v, w);
 
       // Can use Sigma matrix instead: all-orders?
+      // don't need this if we already have Sigma since it is accounted for in Hab(v,w)
       const auto Sigma_vw =
         wf.Sigma() ?
           0.0 :
@@ -300,7 +301,7 @@ calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
       // h1, so need to directly evaluate <w|h1|v>
       const auto h0_vw = wf.Hab(v, w);
 
-      //!!!!!! don't need this if we have Sigma as Hab(v, w) already includes Sigma if it exists
+      //!!! don't need this if we have Sigma as Hab(v, w) already includes Sigma if it exists
       // Can use Sigma matrix instead: all-orders?
       const auto Sigma_vw = wf.Sigma()     ? 0.0 :
                             include_Sigma1 ? v * Sigma_w :

--- a/src/CI/CI_Integrals.hpp
+++ b/src/CI/CI_Integrals.hpp
@@ -174,8 +174,8 @@ calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
 */
 [[nodiscard]] Coulomb::meTable<double>
 calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
-                   const MBPT::CorrelationPotential &Sigma,
-                   bool include_Sigma1);
+                   const MBPT::CorrelationPotential &Sigma, bool include_Sigma1,
+                   const Wavefunction &wf);
 
 /*!
   @brief Builds or loads the two-body Breit integral table.

--- a/src/CI/CI_Integrals.hpp
+++ b/src/CI/CI_Integrals.hpp
@@ -4,6 +4,7 @@
 #include "Coulomb/meTable.hpp"
 #include "LinAlg/Matrix.hpp"
 #include "MBPT/Sigma2.hpp" //temp - remove after refactor
+#include "Wavefunction/Wavefunction.hpp"
 #include <string>
 #include <vector>
 class DiracDiracSpinor;
@@ -154,7 +155,8 @@ double Breit_AB(const CI::CSF2 &A, const CI::CSF2 &B, int twoJ,
 calculate_h1_table(const std::vector<DiracSpinor> &ci_basis,
                    const std::vector<DiracSpinor> &s1_basis_core,
                    const std::vector<DiracSpinor> &s1_basis_excited,
-                   const Coulomb::QkTable &qk, bool include_Sigma1);
+                   const Coulomb::QkTable &qk, bool include_Sigma1,
+                   const Wavefunction &wf);
 
 /*!
   @brief Builds the one-body Hamiltonian table using a precomputed

--- a/src/CI/ConfigurationInteraction.cpp
+++ b/src/CI/ConfigurationInteraction.cpp
@@ -413,17 +413,12 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
       std::cout << "\nCalculate two-body MBPT integrals with all-orders "
                    "screening: Σ^k_abcd\n";
 
-      // std::cout << "For: " << DiracSpinor::state_config(cis2_basis)
-      //           << ", using " << DiracSpinor::state_config(excited_s2) << "\n";
-      // std::cout << std::flush;
-
       const int num_points = wf.grid().num_points();
-      const int num_points_subgrid = num_points / 2;
+      const int num_points_subgrid = num_points / 4; // stride of 4
       const int stride = num_points / num_points_subgrid;
 
       MBPT::Feynman feyn =
-        MBPT::Feynman(wf.vHF(), wf.grid().getIndex(wf.grid().r0()), stride,
-                      num_points_subgrid, {}, 1, true);
+        MBPT::Feynman(wf.vHF(), 0, stride, num_points_subgrid, {}, 1, true);
 
       Sk = MBPT::calculate_Sk_screened(
         Sk_filename, cis2_basis, core_s2, excited_s2, qk, max_k_Coulomb,

--- a/src/CI/ConfigurationInteraction.cpp
+++ b/src/CI/ConfigurationInteraction.cpp
@@ -456,7 +456,6 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
         // and construct each pair of lowest kappa energies to construct polarisation operators
 
         // we only fill in lower half of the matrix to save on memory allocation
-#pragma omp parallel for collapse(3)
         for (int kv_i = kappai_list[0]; kv_i < kappai_list.back(); kv_i++) {
           auto kv = Angular::kindex_to_kappa(kv_i);
           double ebar_v = MBPT::e_bar(kv, cis2_basis);
@@ -464,7 +463,7 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
             auto kw = Angular::kindex_to_kappa(kw_i);
             double ebar_w = MBPT::e_bar(kw, cis2_basis);
             double de = std::abs(ebar_v - ebar_w);
-
+#pragma omp parallel for
             for (int k = 0; k <= max_k_Coulomb; k++) {
               const auto sk = std::size_t(k);
               // do not bother calculating the polarisation operator

--- a/src/CI/ConfigurationInteraction.cpp
+++ b/src/CI/ConfigurationInteraction.cpp
@@ -8,6 +8,7 @@
 #include "IO/InputBlock.hpp"
 #include "LinAlg/Matrix.hpp"
 #include "MBPT/CorrelationPotential.hpp"
+#include "MBPT/Feynman.hpp"
 #include "MBPT/Sigma2.hpp"
 #include "Physics/AtomData.hpp"
 #include "Wavefunction/DiracSpinor.hpp"
@@ -102,7 +103,9 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
      {"print_details", "Condition to print details of each CI solution "
                        "(otherwise just prints summary) [true]"},
      {"parallel_ci", "Run CI in parallel (solve each J/Pi in parallel). "
-                     "Faster, uses slightly more memory [true]"}});
+                     "Faster, uses slightly more memory [true]"},
+     {"Screening",
+      "Includes screened Coulomb interaction into Sigma_2 integrals [false]"}});
 
   // construct first, for RVO
   std::vector<PsiJPi> levels;
@@ -121,6 +124,10 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
   // options to include MBPT
   const auto include_Sigma1 = input.get("sigma1", false);
   const auto include_Sigma2 = input.get("sigma2", false);
+
+  // option to include screening into Sigma^2
+  // should also add option for hole-particle
+  const auto include_Screening = input.get("Screening", false);
 
   // Use Breuckner states for MBPT
   // nb: currently also use these Bruckner states in place of the "core"
@@ -369,25 +376,53 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
 
   Coulomb::LkTable Sk;
   if (include_Sigma2) {
+    if (!include_Screening) {
+      // Here, write basis info into filename, since these are _internal_ lines!
+      const auto Sk_filename =
+        input.get("sk_file", wf.identity() + "_" + std::to_string(n_min_core) +
+                               "_" + DiracSpinor::state_config(excited_s2) +
+                               (max_k_Coulomb >= 0 && max_k_Coulomb < 50 ?
+                                  "_" + std::to_string(max_k_Coulomb) :
+                                  "") +
+                               br_string + ".sk.abf");
 
-    // Here, write basis info into filename, since these are _internal_ lines!
-    const auto Sk_filename =
-      input.get("sk_file", wf.identity() + "_" + std::to_string(n_min_core) +
-                             "_" + DiracSpinor::state_config(excited_s2) +
-                             (max_k_Coulomb >= 0 && max_k_Coulomb < 50 ?
-                                "_" + std::to_string(max_k_Coulomb) :
-                                "") +
-                             br_string + ".sk.abf");
+      std::cout << "\nCalculate two-body MBPT integrals: Σ^k_abcd\n";
 
-    std::cout << "\nCalculate two-body MBPT integrals: Σ^k_abcd\n";
+      std::cout << "For: " << DiracSpinor::state_config(cis2_basis)
+                << ", using " << DiracSpinor::state_config(excited_s2) << "\n";
+      std::cout << std::flush;
 
-    std::cout << "For: " << DiracSpinor::state_config(cis2_basis) << ", using "
-              << DiracSpinor::state_config(excited_s2) << "\n";
-    std::cout << std::flush;
+      Sk = MBPT::calculate_Sk(Sk_filename, cis2_basis, core_s2, excited_s2, qk,
+                              max_k_Coulomb, exclude_wrong_parity_box,
+                              denominators, no_new_integralsQ);
+    } else {
+      // if we have screening then we have no n_min_core as Green's function contains all n
+      const auto Sk_filename = input.get(
+        "sk_file", wf.identity() + "_" + DiracSpinor::state_config(excited_s2) +
+                     (max_k_Coulomb >= 0 && max_k_Coulomb < 50 ?
+                        "_" + std::to_string(max_k_Coulomb) :
+                        "") +
+                     "_" + "AO" + br_string + ".sk.abf");
 
-    Sk = MBPT::calculate_Sk(Sk_filename, cis2_basis, core_s2, excited_s2, qk,
-                            max_k_Coulomb, exclude_wrong_parity_box,
-                            denominators, no_new_integralsQ);
+      std::cout << "\nCalculate two-body MBPT integrals with all-orders "
+                   "screening: Σ^k_abcd\n";
+
+      // std::cout << "For: " << DiracSpinor::state_config(cis2_basis)
+      //           << ", using " << DiracSpinor::state_config(excited_s2) << "\n";
+      // std::cout << std::flush;
+
+      const int num_points = wf.grid().num_points();
+      const int num_points_subgrid = num_points / 2;
+      const int stride = num_points / num_points_subgrid;
+
+      MBPT::Feynman feyn =
+        MBPT::Feynman(wf.vHF(), wf.grid().getIndex(wf.grid().r0()), stride,
+                      num_points_subgrid, {}, 1, true);
+
+      Sk = MBPT::calculate_Sk_screened(
+        Sk_filename, cis2_basis, core_s2, excited_s2, qk, max_k_Coulomb,
+        exclude_wrong_parity_box, denominators, feyn, no_new_integralsQ);
+    }
   }
 
   //----------------------------------------------------------------------------
@@ -420,9 +455,9 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
           std::pair{2 * J_odd_list.at(i - J_even_list.size()), -1};
 
       auto &output_stream = parallel_ci ? os.at(i) : std::cout;
-      levels.at(i) =
-        run_CI(ci_sp_basis, twoj, pi, num_solutions, all_below_cm, h1, qk, Bk,
-               Sk, include_Sigma2, print_details, output_stream);
+      levels.at(i) = run_CI(ci_sp_basis, twoj, pi, num_solutions, all_below_cm,
+                            h1, qk, Bk, Sk, include_Sigma2, include_Screening,
+                            print_details, output_stream);
     }
 
     // If doing in parallel, output detailed output at end
@@ -501,7 +536,7 @@ PsiJPi run_CI(const std::vector<DiracSpinor> &ci_sp_basis, int twoJ, int parity,
               int num_solutions, std::optional<double> all_below_cm,
               const Coulomb::meTable<double> &h1, const Coulomb::QkTable &qk,
               const Coulomb::WkTable &Bk, const Coulomb::LkTable &Sk,
-              bool include_Sigma2, bool print_details,
+              bool include_Sigma2, bool include_Screening, bool print_details,
               std::ostream &outstream) {
 
   auto printJ = [](int twoj) {
@@ -534,6 +569,7 @@ PsiJPi run_CI(const std::vector<DiracSpinor> &ci_sp_basis, int twoJ, int parity,
   // Construct the CI matrix:
   const auto br_ptr = !Bk.emptyQ() ? &Bk : nullptr;
   const auto s2_ptr = include_Sigma2 ? &Sk : nullptr;
+  // const auto AO_ptr = include_Screening ? &Sk : nullptr; // needed?
   const auto Hci = CI::construct_Hci(psi, h1, qk, br_ptr, s2_ptr);
 
   //----------------------------------------------------------------------------

--- a/src/CI/ConfigurationInteraction.cpp
+++ b/src/CI/ConfigurationInteraction.cpp
@@ -334,7 +334,7 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
     Brueckner ?
       CI::calculate_h1_table(ci_sp_basis, {}, {}, {}, false, wf) :
     wf.Sigma() ?
-      CI::calculate_h1_table(ci_sp_basis, *wf.Sigma(), include_Sigma1) :
+      CI::calculate_h1_table(ci_sp_basis, *wf.Sigma(), include_Sigma1, wf) :
       CI::calculate_h1_table(ci_sp_basis, core_s1, excited_s1, qk,
                              include_Sigma1, wf);
 

--- a/src/CI/ConfigurationInteraction.cpp
+++ b/src/CI/ConfigurationInteraction.cpp
@@ -325,11 +325,11 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
   std::cout << std::flush;
   const auto h1 =
     Brueckner ?
-      CI::calculate_h1_table(ci_sp_basis, {}, {}, {}, false) :
+      CI::calculate_h1_table(ci_sp_basis, {}, {}, {}, false, wf) :
     wf.Sigma() ?
       CI::calculate_h1_table(ci_sp_basis, *wf.Sigma(), include_Sigma1) :
       CI::calculate_h1_table(ci_sp_basis, core_s1, excited_s1, qk,
-                             include_Sigma1);
+                             include_Sigma1, wf);
 
   //----------------------------------------------------------------------------
   // Breit and QED
@@ -357,8 +357,14 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
     std::cout << "For: " << DiracSpinor::state_config(Breit_basis) << "\n";
     std::cout << std::flush;
 
+    // add extra f if we have frequency-dependent Breit or not
+    // might not always want this to follow what's in HF if we are testing
+    // impact of FD-Breit
+    const std::string fBreit_string =
+      wf.vHF()->vBreit()->lambda_f() == 0.0 ? "" : "f";
+
     const auto bk_filename =
-      input.get("bk_file", wf.identity() + br_string + ".bk");
+      input.get("bk_file", wf.identity() + fBreit_string + br_string + ".bk");
 
     Bk = CI::calculate_Bk(bk_filename, wf.vHF()->vBreit(), Breit_basis,
                           max_k_Coulomb, no_new_integralsQ);

--- a/src/CI/ConfigurationInteraction.cpp
+++ b/src/CI/ConfigurationInteraction.cpp
@@ -454,6 +454,8 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
 
         // if the denominators are =Fermi then we loop over each kappa in valence list
         // and construct each pair of lowest kappa energies to construct polarisation operators
+
+        // we only fill in lower half of the matrix to save on memory allocation
 #pragma omp parallel for collapse(3)
         for (int kv_i = kappai_list[0]; kv_i < kappai_list.back(); kv_i++) {
           auto kv = Angular::kindex_to_kappa(kv_i);
@@ -479,14 +481,13 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
               dQ_screen_Fermi[k](kv_i, kw_i) =
                 feyn.dQ_screen_k(sk, de, true, true);
               // fill symmetric lower half of matrix
-              dQ_screen_Fermi[sk](kw_i, kv_i) =
-                dQ_screen_Fermi[sk](kv_i, kw_i); // needed? seems to be wasteful
+              // dQ_screen_Fermi[sk](kw_i, kv_i) =
+              //   dQ_screen_Fermi[sk](kv_i, kw_i); // instead will just only use bottom half
             }
           }
         }
       }
 
-      // with RS denominators, this will be incredibly slow
       Sk = MBPT::calculate_Sk_screened(
         Sk_filename, cis2_basis, core_s2, excited_s2, qk, max_k_Coulomb,
         exclude_wrong_parity_box, denominators, dQ_screen, dQ_screen_Fermi,
@@ -523,9 +524,9 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
           std::pair{2 * J_odd_list.at(i - J_even_list.size()), -1};
 
       auto &output_stream = parallel_ci ? os.at(i) : std::cout;
-      levels.at(i) = run_CI(ci_sp_basis, twoj, pi, num_solutions, all_below_cm,
-                            h1, qk, Bk, Sk, include_Sigma2, include_Screening,
-                            print_details, output_stream);
+      levels.at(i) =
+        run_CI(ci_sp_basis, twoj, pi, num_solutions, all_below_cm, h1, qk, Bk,
+               Sk, include_Sigma2, print_details, output_stream);
     }
 
     // If doing in parallel, output detailed output at end
@@ -604,7 +605,7 @@ PsiJPi run_CI(const std::vector<DiracSpinor> &ci_sp_basis, int twoJ, int parity,
               int num_solutions, std::optional<double> all_below_cm,
               const Coulomb::meTable<double> &h1, const Coulomb::QkTable &qk,
               const Coulomb::WkTable &Bk, const Coulomb::LkTable &Sk,
-              bool include_Sigma2, bool include_Screening, bool print_details,
+              bool include_Sigma2, bool print_details,
               std::ostream &outstream) {
 
   auto printJ = [](int twoj) {

--- a/src/CI/ConfigurationInteraction.cpp
+++ b/src/CI/ConfigurationInteraction.cpp
@@ -415,7 +415,7 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
                    "screening: Σ^k_abcd\n";
 
       const int num_points = wf.grid().num_points();
-      const int num_points_subgrid = num_points / 4; // stride of 4
+      const int num_points_subgrid = num_points / 4; // stride in denominator
       const int stride = num_points / num_points_subgrid;
 
       // should make it so that the Feynman class constructs the screening
@@ -423,13 +423,16 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
       // writes it to a file
       MBPT::Feynman feyn = MBPT::Feynman(
         wf.vHF(), 0, stride, num_points_subgrid, {}, 1, true, true, false);
-      std::vector<MBPT::ComplexRMatrix> Q_screen =
-        feyn.Q_screen(max_k_Coulomb, 0.0, true);
+
+      // construct the screening part of Qtilde at small negative frequency, w = -0.1
+      // constructing it at exactly w = 0.0 is numerically unstable
+      const std::vector<MBPT::ComplexRMatrix> dQ_screen =
+        feyn.dQ_screen(max_k_Coulomb, -0.1, true, true);
 
       // with RS denominators, this will be incredibly slow
       Sk = MBPT::calculate_Sk_screened(
         Sk_filename, cis2_basis, core_s2, excited_s2, qk, max_k_Coulomb,
-        exclude_wrong_parity_box, denominators, Q_screen, no_new_integralsQ);
+        exclude_wrong_parity_box, denominators, dQ_screen, no_new_integralsQ);
     }
   }
 

--- a/src/CI/ConfigurationInteraction.cpp
+++ b/src/CI/ConfigurationInteraction.cpp
@@ -414,28 +414,85 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
       std::cout << "\nCalculate two-body MBPT integrals with all-orders "
                    "screening: Σ^k_abcd\n";
 
-      const int num_points = wf.grid().num_points();
-      const int num_points_subgrid = num_points / 4; // stride in denominator
-      const int stride = num_points / num_points_subgrid;
+      const std::size_t i0 = 0;
+      const std::size_t num_points = wf.grid().num_points();
+      const std::size_t num_points_subgrid =
+        num_points / 4; // stride in denominator
+      const std::size_t stride = num_points / num_points_subgrid;
 
-      // should make it so that the Feynman class constructs the screening
+      //! should make it so that the Feynman class constructs the screening
       // parts of the Coulomb interaction if we set it up to do CI and
       // writes it to a file
       MBPT::Feynman feyn = MBPT::Feynman(
-        wf.vHF(), 0, stride, num_points_subgrid, {}, 1, true, true, false);
+        wf.vHF(), i0, stride, num_points_subgrid, {}, 1, true, true, false);
 
       // construct the screening part of Qtilde at small negative frequency, w = -0.1
       // constructing it at exactly w = 0.0 is numerically unstable
       const std::vector<MBPT::ComplexRMatrix> dQ_screen =
         feyn.dQ_screen(max_k_Coulomb, -0.1, true, true);
 
+      // extract list of kappa from S^2 basis
+      const auto kappai_list = AtomData::kappa_index_list(cis2_basis_string);
+
+      std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> dQ_screen_Fermi(
+        max_k_Coulomb,
+        {kappai_list.size(), kappai_list.size(),
+         MBPT::ComplexRMatrix{i0, stride, num_points_subgrid, wf.grid_sptr()}});
+
+      // right now will do this if we have Fermi or RS denoms.
+      // technically RS denoms should do this for all pairs but this will be too long
+      if (denominators == MBPT::Denominators::Fermi ||
+          denominators == MBPT::Denominators::RS) {
+
+        // extract list of kappa from S^2 basis
+        // const auto kappai_list = AtomData::kappa_index_list(cis2_basis_string);
+
+        // form dQ_Fermi as a vector of matrices of polarisation operators
+        // vector component for each kappa while each matrix entry for each combination of kappa
+        // std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> dQ_screen_Fermi(
+        //   max_k_Coulomb, {kappai_list.size(), kappai_list.size()});
+
+        // if the denominators are =Fermi then we loop over each kappa in valence list
+        // and construct each pair of lowest kappa energies to construct polarisation operators
+#pragma omp parallel for collapse(3)
+        for (int kv_i = kappai_list[0]; kv_i < kappai_list.back(); kv_i++) {
+          auto kv = Angular::kindex_to_kappa(kv_i);
+          double ebar_v = MBPT::e_bar(kv, cis2_basis);
+          for (int kw_i = 0; kw_i < kv_i; kw_i++) {
+            auto kw = Angular::kindex_to_kappa(kw_i);
+            double ebar_w = MBPT::e_bar(kw, cis2_basis);
+            double de = std::abs(ebar_v - ebar_w);
+
+            for (int k = 0; k <= max_k_Coulomb; k++) {
+              const auto sk = std::size_t(k);
+              // do not bother calculating the polarisation operator
+              // if the matrix element <vx|dQ|wy> will be zero
+              if (Angular::Ck_kk(sk, kv, kw) == 0.0) {
+                continue;
+              }
+              // if de ~= 0.0, can just use the w = 0.0 matrix element we have evaluated outside
+              if (std::abs(de) <= 0.1) {
+                dQ_screen_Fermi[sk](kv_i, kw_i) = dQ_screen[k];
+                continue;
+              }
+
+              dQ_screen_Fermi[k](kv_i, kw_i) =
+                feyn.dQ_screen_k(sk, de, true, true);
+              // fill symmetric lower half of matrix
+              dQ_screen_Fermi[sk](kw_i, kv_i) =
+                dQ_screen_Fermi[sk](kv_i, kw_i); // needed? seems to be wasteful
+            }
+          }
+        }
+      }
+
       // with RS denominators, this will be incredibly slow
       Sk = MBPT::calculate_Sk_screened(
         Sk_filename, cis2_basis, core_s2, excited_s2, qk, max_k_Coulomb,
-        exclude_wrong_parity_box, denominators, dQ_screen, no_new_integralsQ);
+        exclude_wrong_parity_box, denominators, dQ_screen, dQ_screen_Fermi,
+        no_new_integralsQ);
     }
   }
-
   //----------------------------------------------------------------------------
   const auto J_list = input.get("J", std::vector<int>{});
   const auto J_even_list = input.get("J+", J_list);

--- a/src/CI/ConfigurationInteraction.cpp
+++ b/src/CI/ConfigurationInteraction.cpp
@@ -9,6 +9,7 @@
 #include "LinAlg/Matrix.hpp"
 #include "MBPT/CorrelationPotential.hpp"
 #include "MBPT/Feynman.hpp"
+#include "MBPT/RadialMatrix.hpp"
 #include "MBPT/Sigma2.hpp"
 #include "Physics/AtomData.hpp"
 #include "Wavefunction/DiracSpinor.hpp"
@@ -417,12 +418,18 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
       const int num_points_subgrid = num_points / 4; // stride of 4
       const int stride = num_points / num_points_subgrid;
 
-      MBPT::Feynman feyn =
-        MBPT::Feynman(wf.vHF(), 0, stride, num_points_subgrid, {}, 1, true);
+      // should make it so that the Feynman class constructs the screening
+      // parts of the Coulomb interaction if we set it up to do CI and
+      // writes it to a file
+      MBPT::Feynman feyn = MBPT::Feynman(
+        wf.vHF(), 0, stride, num_points_subgrid, {}, 1, true, true, false);
+      std::vector<MBPT::ComplexRMatrix> Q_screen =
+        feyn.Q_screen(max_k_Coulomb, 0.0, true);
 
+      // with RS denominators, this will be incredibly slow
       Sk = MBPT::calculate_Sk_screened(
         Sk_filename, cis2_basis, core_s2, excited_s2, qk, max_k_Coulomb,
-        exclude_wrong_parity_box, denominators, feyn, no_new_integralsQ);
+        exclude_wrong_parity_box, denominators, Q_screen, no_new_integralsQ);
     }
   }
 

--- a/src/CI/ConfigurationInteraction.cpp
+++ b/src/CI/ConfigurationInteraction.cpp
@@ -17,6 +17,7 @@
 #include "fmt/format.hpp"
 #include "fmt/ostream.hpp"
 #include "qip/Vector.hpp"
+#include "qip/Widgets.hpp"
 #include <array>
 #include <fstream>
 #include <iostream>
@@ -434,7 +435,7 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
       // extract list of kappa from S^2 basis
       const auto kappai_list = AtomData::kappa_index_list(cis2_basis_string);
 
-      std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> dQ_screen_Fermi(
+      std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> PiMatrix(
         max_k_Coulomb,
         {kappai_list.size(), kappai_list.size(),
          MBPT::ComplexRMatrix{i0, stride, num_points_subgrid, wf.grid_sptr()}});
@@ -444,53 +445,50 @@ std::vector<PsiJPi> configuration_interaction(const IO::InputBlock &input,
       if (denominators == MBPT::Denominators::Fermi ||
           denominators == MBPT::Denominators::RS) {
 
-        // extract list of kappa from S^2 basis
-        // const auto kappai_list = AtomData::kappa_index_list(cis2_basis_string);
+        IO::ChronoTimer timer("Filling Pi matrix:");
 
-        // form dQ_Fermi as a vector of matrices of polarisation operators
-        // vector component for each kappa while each matrix entry for each combination of kappa
-        // std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> dQ_screen_Fermi(
-        //   max_k_Coulomb, {kappai_list.size(), kappai_list.size()});
+        MBPT::FillPiMatrix(max_k_Coulomb, cis2_basis, cis2_basis_string,
+                           kappai_list, feyn, PiMatrix);
 
-        // if the denominators are =Fermi then we loop over each kappa in valence list
-        // and construct each pair of lowest kappa energies to construct polarisation operators
+        //         // we only fill in lower half of the matrix to save on memory allocation
+        //         qip::ProgressBar bar(kappai_list.size(), true);
+        //         for (int kv_i = kappai_list[0]; kv_i < kappai_list.back(); kv_i++) {
+        //           auto kv = Angular::kindex_to_kappa(kv_i);
+        //           double ebar_v = MBPT::e_bar(kv, cis2_basis);
+        //           for (int kw_i = 0; kw_i < kv_i; kw_i++) {
+        //             auto kw = Angular::kindex_to_kappa(kw_i);
+        //             double ebar_w = MBPT::e_bar(kw, cis2_basis);
+        //             double de = std::abs(ebar_v - ebar_w);
+        // #pragma omp parallel for
+        //             for (int k = 0; k <= max_k_Coulomb; k++) {
+        //               const auto sk = std::size_t(k);
+        //               // do not bother calculating the polarisation operator
+        //               // if the matrix element <vx|dQ|wy> will be zero
+        //               if (Angular::Ck_kk(sk, kv, kw) == 0.0) {
+        //                 continue;
+        //               }
 
-        // we only fill in lower half of the matrix to save on memory allocation
-        for (int kv_i = kappai_list[0]; kv_i < kappai_list.back(); kv_i++) {
-          auto kv = Angular::kindex_to_kappa(kv_i);
-          double ebar_v = MBPT::e_bar(kv, cis2_basis);
-          for (int kw_i = 0; kw_i < kv_i; kw_i++) {
-            auto kw = Angular::kindex_to_kappa(kw_i);
-            double ebar_w = MBPT::e_bar(kw, cis2_basis);
-            double de = std::abs(ebar_v - ebar_w);
-#pragma omp parallel for
-            for (int k = 0; k <= max_k_Coulomb; k++) {
-              const auto sk = std::size_t(k);
-              // do not bother calculating the polarisation operator
-              // if the matrix element <vx|dQ|wy> will be zero
-              if (Angular::Ck_kk(sk, kv, kw) == 0.0) {
-                continue;
-              }
-              // if de ~= 0.0, can just use the w = 0.0 matrix element we have evaluated outside
-              if (std::abs(de) <= 0.1) {
-                dQ_screen_Fermi[sk](kv_i, kw_i) = dQ_screen[k];
-                continue;
-              }
+        //               // if de ~= 0.0, can just use the w = 0.0 matrix element we have evaluated outside
+        //               if (std::abs(de) <= 0.1) {
+        //                 // dQ_screen_Fermi[sk](kv_i, kw_i) = dQ_screen[k];
+        //                 continue;
+        //               }
 
-              dQ_screen_Fermi[k](kv_i, kw_i) =
-                feyn.dQ_screen_k(sk, de, true, true);
-              // fill symmetric lower half of matrix
-              // dQ_screen_Fermi[sk](kw_i, kv_i) =
-              //   dQ_screen_Fermi[sk](kv_i, kw_i); // instead will just only use bottom half
-            }
-          }
-        }
+        //               dQ_screen_Fermi[k](kv_i, kw_i) =
+        //                 feyn.dQ_screen_k(sk, de, true, true);
+        //               // fill symmetric lower half of matrix
+        //               // dQ_screen_Fermi[sk](kw_i, kv_i) =
+        //               //   dQ_screen_Fermi[sk](kv_i, kw_i); // instead will just only use bottom half
+        //             }
+        //           }
+        //           bar.update();
+        //         }
       }
 
-      Sk = MBPT::calculate_Sk_screened(
-        Sk_filename, cis2_basis, core_s2, excited_s2, qk, max_k_Coulomb,
-        exclude_wrong_parity_box, denominators, dQ_screen, dQ_screen_Fermi,
-        no_new_integralsQ);
+      Sk = MBPT::calculate_Sk_screened(Sk_filename, cis2_basis, core_s2,
+                                       excited_s2, qk, max_k_Coulomb,
+                                       exclude_wrong_parity_box, denominators,
+                                       dQ_screen, PiMatrix, no_new_integralsQ);
     }
   }
   //----------------------------------------------------------------------------

--- a/src/CI/ConfigurationInteraction.hpp
+++ b/src/CI/ConfigurationInteraction.hpp
@@ -201,7 +201,7 @@ PsiJPi run_CI(const std::vector<DiracSpinor> &ci_sp_basis, int twoJ, int parity,
               int num_solutions, std::optional<double> all_below_cm,
               const Coulomb::meTable<double> &h1, const Coulomb::QkTable &qk,
               const Coulomb::WkTable &Bk, const Coulomb::LkTable &Sk,
-              bool include_Sigma2, bool print_details,
+              bool include_Sigma2, bool include_Screening, bool print_details,
               std::ostream &outstream = std::cout);
 
 } // namespace CI

--- a/src/CI/ConfigurationInteraction.hpp
+++ b/src/CI/ConfigurationInteraction.hpp
@@ -201,7 +201,7 @@ PsiJPi run_CI(const std::vector<DiracSpinor> &ci_sp_basis, int twoJ, int parity,
               int num_solutions, std::optional<double> all_below_cm,
               const Coulomb::meTable<double> &h1, const Coulomb::QkTable &qk,
               const Coulomb::WkTable &Bk, const Coulomb::LkTable &Sk,
-              bool include_Sigma2, bool include_Screening, bool print_details,
+              bool include_Sigma2, bool print_details,
               std::ostream &outstream = std::cout);
 
 } // namespace CI

--- a/src/Coulomb/Coulomb.tests.cpp
+++ b/src/Coulomb/Coulomb.tests.cpp
@@ -710,9 +710,9 @@ TEST_CASE("Coulomb: operator form", "[Coulomb][integration][k7]") {
   //============================================================================
   // test calculation of matrix elements with operator method versus direct calculation
   {
-    const int num_points = wf.grid().num_points();
-    const int num_points_subgrid = num_points / 4;
-    const int stride = num_points / num_points_subgrid;
+    const auto num_points = wf.grid().num_points();
+    const auto num_points_subgrid = num_points / 4;
+    const auto stride = num_points / num_points_subgrid;
     const int i0 = 0; // default i0 value
 
     MBPT::Feynman feyn =

--- a/src/Coulomb/Coulomb.tests.cpp
+++ b/src/Coulomb/Coulomb.tests.cpp
@@ -711,29 +711,26 @@ TEST_CASE("Coulomb: operator form", "[Coulomb][integration][k7]") {
   // test calculation of matrix elements with operator method versus direct calculation
   {
     const int num_points = wf.grid().num_points();
-    const int num_points_subgrid = num_points / 2;
+    const int num_points_subgrid = num_points / 4;
     const int stride = num_points / num_points_subgrid;
-    // const int num_points_subgrid = 800;
-    // const int stride = (wf.grid().getIndex(30.0) - wf.grid().getIndex(1.0e-4)) /
-    //                    num_points_subgrid;
-    const int i0 = wf.grid().getIndex(1.0e-6); // default i0 value
+    const int i0 = 0; // default i0 value
 
     MBPT::Feynman feyn =
       MBPT::Feynman(wf.vHF(), i0, stride, num_points_subgrid, {}, 1, true);
 
     const std::pair<double, double> eps_R =
       UnitTest::check_Rkabcd_operator(wf.core(), feyn, 1);
-    // const std::pair<double, double> eps_R2 =
-    //   UnitTest::check_Rkabcd_operator(wf.basis(), feyn, 1);
+    const std::pair<double, double> eps_R2 =
+      UnitTest::check_Rkabcd_operator(wf.basis(), feyn, 1);
 
     // if R^k_{abcd} is small (R <= 1.0e-9) then they only need to agree to parts in 10^-3
     // if R is big (R > 1.0e-9) then they need to agree to parts in 10^-9
     const double eps_threshold_big = 1.0e-9;
     const double eps_threshold_small = 1.0e-3;
     CHECK(std::fabs(eps_R.first) <= eps_threshold_small);
-    // CHECK(std::fabs(eps_R2.first) <= eps_threshold_small);
+    CHECK(std::fabs(eps_R2.first) <= eps_threshold_small);
     CHECK(std::fabs(eps_R.second) <= eps_threshold_big);
-    // CHECK(std::fabs(eps_R2.second) <= eps_threshold_big);
+    CHECK(std::fabs(eps_R2.second) <= eps_threshold_big);
   }
 }
 
@@ -927,10 +924,16 @@ UnitTest::check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
             const auto eps = std::fabs((R_exact - R_operator) / R_exact);
 #pragma omp critical(compare_epsR_operator)
             {
+              std::cout << R_exact << "  " << R_operator << " " << eps
+                        << std::endl;
+              if (eps > 1.0e-1) {
+                std::cin.get();
+              }
               if (R_exact >= 1.0e-6) {
                 if (eps > eps_R_big) {
                   eps_R_big = eps;
                 }
+
               } else {
                 if (eps > eps_R_small) {
                   eps_R_small = eps;

--- a/src/Coulomb/Coulomb.tests.cpp
+++ b/src/Coulomb/Coulomb.tests.cpp
@@ -3,6 +3,7 @@
 #include "Coulomb/CoulombIntegrals.hpp"
 #include "Coulomb/YkTable.hpp"
 #include "IO/ChronoTimer.hpp"
+#include "MBPT/Feynman.hpp"
 #include "Maths/Grid.hpp"
 #include "Maths/NumCalc_quadIntegrate.hpp"
 #include "Wavefunction/Wavefunction.hpp"
@@ -46,6 +47,10 @@ inline std::vector<double> check_ykab(const std::vector<DiracSpinor> &orbs,
 // functions. Compares them all, and resturns worst comparison.
 inline double check_Rkabcd(const std::vector<DiracSpinor> &orbs,
                            int max_del_n = 99);
+
+inline double check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
+                                    const MBPT::Feynman &feyn,
+                                    int max_del_n = 99);
 
 } // namespace UnitTest
 
@@ -691,6 +696,35 @@ TEST_CASE("Coulomb: formulas", "[Coulomb][integration]") {
   }
 }
 
+//==============================================================================
+//==============================================================================
+//! Unit tests for calculating Coulomb matrix elements from coordinate operator
+TEST_CASE("Coulomb: operator form", "[Coulomb][integration][k7]") {
+
+  // Test the Coulomb formulas
+  Wavefunction wf({900, 1.0e-6, 100.0, 10.0, "loglinear", -1.0},
+                  {"Na", -1, "Fermi", -1.0, -1.0}, 1.0);
+  wf.solve_core("HartreeFock", std::nullopt, "[Ne]");
+  wf.formBasis({"4spd6fg8h8i", 30, 7, 1.0e-3, 1.0e-3, 40.0});
+
+  //============================================================================
+  // test calculation of matrix elements with operator method versus direct calculation
+  {
+    const int num_points = wf.grid().num_points();
+    const int num_points_subgrid = num_points / 2;
+    const int stride = num_points / num_points_subgrid;
+
+    MBPT::Feynman feyn =
+      MBPT::Feynman(wf.vHF(), 0, stride, num_points_subgrid, {}, 1, true);
+
+    const double eps_R = UnitTest::check_Rkabcd_operator(wf.core(), feyn, 1);
+    const double eps_R2 = UnitTest::check_Rkabcd_operator(wf.basis(), feyn, 1);
+
+    CHECK(std::fabs(eps_R) <= 1e-3);
+    CHECK(std::fabs(eps_R2) <= 1e-3);
+  }
+}
+
 //============================================================================
 //============================================================================
 
@@ -830,6 +864,54 @@ double UnitTest::check_Rkabcd(const std::vector<DiracSpinor> &orbs,
             const auto r4 = Fa * Coulomb::Rkv_bcd(Fa.kappa(), Fc, *ybd);
             const auto eps = std::max({r1a, r1b, r1c, r2a, r2b, r2c, r3, r4}) -
                              std::min({r1a, r1b, r1c, r2a, r2b, r2c, r3, r4});
+#pragma omp critical(compare_epsR)
+            if (eps > eps_R) {
+              eps_R = eps;
+            }
+          }
+        }
+      }
+    }
+  }
+  return eps_R;
+}
+
+//============================================================================
+double UnitTest::check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
+                                       const MBPT::Feynman &feyn,
+                                       int max_del_n) {
+  double eps_R = 0.0;
+  const Coulomb::YkTable Yab(orbs);
+#pragma omp parallel for
+  for (auto ia = 0ul; ia < orbs.size(); ia++) {
+    const auto &Fa = orbs[ia];
+    for (auto ib = 0ul; ib < orbs.size(); ib += 2) {
+      const auto &Fb = orbs[ib];
+      for (auto ic = ia; ic < orbs.size(); ic++) {
+        const auto &Fc = orbs[ic];
+        if (std::abs(Fa.n() - Fc.n()) > max_del_n)
+          continue;
+        if (std::abs(Fb.n() - Fc.n()) > max_del_n)
+          continue;
+        for (auto id = ib; id < orbs.size(); id += 2) {
+          const auto &Fd = orbs[id];
+          if (std::abs(Fb.n() - Fd.n()) > max_del_n)
+            continue;
+          const auto [kmin, kmax] = Coulomb::k_minmax_Ck(Fa, Fc);
+          for (int k = kmin; k <= kmax; ++k) {
+            if (!Angular::Ck_kk_SR(k, Fa.kappa(), Fc.kappa()))
+              continue;
+            if (!Angular::Ck_kk_SR(k, Fb.kappa(), Fd.kappa()))
+              continue;
+
+            //---------
+            const auto ybd = Yab.get(k, Fb, Fd);
+
+            const auto R_exact = Coulomb::Rk_abcd(Fa, Fc, *ybd);
+            const auto R_operator =
+              MBPT::two_body_ME(feyn.get_qk(k).dri(), Fa, Fb, Fc, Fd);
+
+            const auto eps = std::fabs((R_exact - R_operator) / R_exact);
 #pragma omp critical(compare_epsR)
             if (eps > eps_R) {
               eps_R = eps;

--- a/src/Coulomb/Coulomb.tests.cpp
+++ b/src/Coulomb/Coulomb.tests.cpp
@@ -1000,7 +1000,7 @@ UnitTest::check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
 
             const auto R_exact = Coulomb::Rk_abcd(Fa, Fc, *ybd);
             const auto R_operator =
-              MBPT::two_body_ME(feyn.get_qk(k).dri(), Fa, Fb, Fc, Fd);
+              MBPT::Matrix_ME(feyn.get_qk(k).dri(), Fa, Fb, Fc, Fd);
 
             const auto eps = std::fabs((R_exact - R_operator) / R_exact);
 #pragma omp critical(compare_epsR_operator)
@@ -1073,7 +1073,7 @@ std::pair<double, double> UnitTest::check_screened_Rkabcd_operator(
               k, Fa, Fb, Fc, Fd, core, excited, qk);
 
             const auto R_screen_operator =
-              MBPT::two_body_ME(qpiq[k], Fa, Fb, Fc, Fd);
+              MBPT::Matrix_ME(qpiq[k], Fa, Fb, Fc, Fd);
 
             // for if I want to test Q^k_{vwxy}
             // const auto R_screen_operator =

--- a/src/Coulomb/Coulomb.tests.cpp
+++ b/src/Coulomb/Coulomb.tests.cpp
@@ -725,6 +725,8 @@ TEST_CASE("Coulomb: operator form", "[Coulomb][integration][k7]") {
 
     // if R^k_{abcd} is small (R <= 1.0e-9) then they only need to agree to parts in 10^-3
     // if R is big (R > 1.0e-9) then they need to agree to parts in 10^-9
+    //!!!! My threshold for what is big is too large -- need to reduce to ~ 10^-2
+    // run test to see what I mean
     const double eps_threshold_big = 1.0e-9;
     const double eps_threshold_small = 1.0e-3;
     CHECK(std::fabs(eps_R.first) <= eps_threshold_small);

--- a/src/Coulomb/Coulomb.tests.cpp
+++ b/src/Coulomb/Coulomb.tests.cpp
@@ -4,6 +4,7 @@
 #include "Coulomb/YkTable.hpp"
 #include "IO/ChronoTimer.hpp"
 #include "MBPT/Feynman.hpp"
+#include "MBPT/Sigma2.hpp"
 #include "Maths/Grid.hpp"
 #include "Maths/NumCalc_quadIntegrate.hpp"
 #include "Wavefunction/Wavefunction.hpp"
@@ -51,6 +52,20 @@ inline double check_Rkabcd(const std::vector<DiracSpinor> &orbs,
 inline std::pair<double, double>
 check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
                       const MBPT::Feynman &feyn, int max_del_n = 99);
+
+// checks the first order screening matrix elements - sum over states versus radial operator/Feynman approach
+inline std::pair<double, double> check_screened_Rkabcd_operator(
+  const std::vector<DiracSpinor> &orbs, const std::vector<DiracSpinor> &core,
+  const std::vector<DiracSpinor> &excited, const Coulomb::QkTable &qk,
+  const std::vector<MBPT::ComplexRMatrix> &qpiq, int max_del_n = 99);
+
+// calculates the first-order screened Coulomb matrix element with sum over states approach and Yk table
+inline double First_Order_Screen_Sk(const int &k, const DiracSpinor &v,
+                                    const DiracSpinor &w, const DiracSpinor &x,
+                                    const DiracSpinor &y,
+                                    const std::vector<DiracSpinor> &core,
+                                    const std::vector<DiracSpinor> &excited,
+                                    const Coulomb::QkTable &qk);
 
 } // namespace UnitTest
 
@@ -703,20 +718,20 @@ TEST_CASE("Coulomb: operator form", "[Coulomb][integration][k7]") {
 
   // Test the Coulomb formulas
   Wavefunction wf({900, 1.0e-6, 100.0, 10.0, "loglinear", -1.0},
-                  {"Na", -1, "Fermi", -1.0, -1.0}, 1.0);
-  wf.solve_core("HartreeFock", std::nullopt, "[Ne]");
+                  {"Li", -1, "Fermi", -1.0, -1.0}, 1.0);
+  wf.solve_core("HartreeFock", std::nullopt, "[He]");
   wf.formBasis({"4spd6fg8h8i", 30, 7, 1.0e-3, 1.0e-3, 40.0});
 
   //============================================================================
   // test calculation of matrix elements with operator method versus direct calculation
   {
     const auto num_points = wf.grid().num_points();
-    const auto num_points_subgrid = num_points / 4;
+    const auto num_points_subgrid = num_points / 2;
     const auto stride = num_points / num_points_subgrid;
     const int i0 = 0; // default i0 value
 
-    MBPT::Feynman feyn =
-      MBPT::Feynman(wf.vHF(), i0, stride, num_points_subgrid, {}, 1, true);
+    MBPT::Feynman feyn = MBPT::Feynman(wf.vHF(), i0, stride, num_points_subgrid,
+                                       {}, 1, true, true);
 
     const std::pair<double, double> eps_R =
       UnitTest::check_Rkabcd_operator(wf.core(), feyn, 1);
@@ -733,6 +748,70 @@ TEST_CASE("Coulomb: operator form", "[Coulomb][integration][k7]") {
     CHECK(std::fabs(eps_R2.first) <= eps_threshold_small);
     CHECK(std::fabs(eps_R.second) <= eps_threshold_big);
     CHECK(std::fabs(eps_R2.second) <= eps_threshold_big);
+  }
+}
+
+//==============================================================================
+//==============================================================================
+//! Unit test for calculating first order screening matrix elements with sum over states versus coordinate operator
+TEST_CASE("Coulomb screening: operator form", "[Coulomb][integration][g0]") {
+
+  // Test the Coulomb formulas
+  Wavefunction wf({900, 1.0e-7, 60.0, 10.0, "loglinear", -1.0},
+                  {"Li", -1, "Fermi", -1.0, -1.0}, 1.0);
+  wf.solve_core("HartreeFock", std::nullopt, "[He]");
+  wf.formBasis({"20spdfghi", 40, 7, 1.0e-4, 1.0e-3, 40.0});
+
+  const auto [core, excited] =
+    MBPT::split_basis(wf.basis(), wf.FermiLevel(), 1);
+
+  const int max_k_Coulomb = 10;
+
+  // Lookup table; stores all qk's
+  Coulomb::QkTable qk;
+  const Coulomb::YkTable yk(wf.basis());
+  qk.fill(wf.basis(), yk, max_k_Coulomb, false);
+
+  //============================================================================
+  // test calculation of matrix elements with operator method versus direct calculation
+  {
+    const auto num_points = wf.grid().num_points();
+    const auto num_points_subgrid = num_points / 4;
+    const auto stride = num_points / num_points_subgrid;
+    const int i0 = 0; // default i0 value
+
+    MBPT::Feynman feyn = MBPT::Feynman(
+      wf.vHF(), i0, stride, num_points_subgrid,
+      MBPT::FeynmanOptions{.max_l_internal = 6}, 1, true, true, false);
+
+    // size max_k + 1 since we calculate qpiq for k=0 up to k=kmax
+    std::vector<MBPT::ComplexRMatrix> qpiq(
+      max_k_Coulomb + 1,
+      MBPT::ComplexRMatrix{i0, stride, num_points_subgrid, wf.grid_sptr()});
+
+    // evaluate the screening parts of the Coulomb interaction at small w
+    // w = 0 leads to numerical instability
+#pragma omp parallel for
+    for (int k = 0; k <= max_k_Coulomb; k++) {
+      qpiq[k] = feyn.dQ_screen_k(k, -0.1, false, false);
+    }
+
+    const std::pair<double, double> eps_R =
+      UnitTest::check_screened_Rkabcd_operator(wf.basis(), core, excited, qk,
+                                               qpiq, 2);
+    // const std::pair<double, double> eps_R2 =
+    //   UnitTest::check_Rkabcd_operator(wf.basis(), feyn, 1);
+
+    // // if R^k_{abcd} is small (R <= 1.0e-9) then they only need to agree to parts in 10^-3
+    // // if R is big (R > 1.0e-9) then they need to agree to parts in 10^-9
+    // //!!!! My threshold for what is big is too large -- need to reduce to ~ 10^-2
+    // // run test to see what I mean
+    // const double eps_threshold_big = 1.0e-9;
+    // const double eps_threshold_small = 1.0e-3;
+    // CHECK(std::fabs(eps_R.first) <= eps_threshold_small);
+    // CHECK(std::fabs(eps_R2.first) <= eps_threshold_small);
+    // CHECK(std::fabs(eps_R.second) <= eps_threshold_big);
+    // CHECK(std::fabs(eps_R2.second) <= eps_threshold_big);
   }
 }
 
@@ -926,6 +1005,8 @@ UnitTest::check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
             const auto eps = std::fabs((R_exact - R_operator) / R_exact);
 #pragma omp critical(compare_epsR_operator)
             {
+              std::cout << Fa << " " << Fb << " " << Fc << " " << Fd << " " << k
+                        << " " << Yab.Q(k, Fa, Fb, Fc, Fd) << "\n";
               std::cout << R_exact << "  " << R_operator << " " << eps
                         << std::endl;
               if (eps > 1.0e-1) {
@@ -948,4 +1029,129 @@ UnitTest::check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
     }
   }
   return {eps_R_small, eps_R_big};
+}
+
+//============================================================================
+std::pair<double, double> UnitTest::check_screened_Rkabcd_operator(
+  const std::vector<DiracSpinor> &orbs, const std::vector<DiracSpinor> &core,
+  const std::vector<DiracSpinor> &excited, const Coulomb::QkTable &qk,
+  const std::vector<MBPT::ComplexRMatrix> &qpiq, int max_del_n) {
+  double eps_R_big = 0.0;
+  double eps_R_small = 0.0;
+
+#pragma omp parallel for
+  for (auto ia = 0ul; ia < orbs.size(); ia++) {
+    const auto &Fa = orbs[ia];
+    const int ka = Fa.kappa();
+    for (auto ib = 0ul; ib < orbs.size(); ib += 2) {
+      const auto &Fb = orbs[ib];
+      const int kb = Fb.kappa();
+      for (auto ic = ia; ic < orbs.size(); ic++) {
+        const auto &Fc = orbs[ic];
+        const int kc = Fc.kappa();
+        if (std::abs(Fa.n() - Fc.n()) > max_del_n)
+          continue;
+        if (std::abs(Fb.n() - Fc.n()) > max_del_n)
+          continue;
+        for (auto id = ib; id < orbs.size(); id += 2) {
+          const auto &Fd = orbs[id];
+          if (std::abs(Fb.n() - Fd.n()) > max_del_n)
+            continue;
+          const auto [kmin, kmax] = Coulomb::k_minmax_Ck(Fa, Fc);
+          for (int k = kmin; k <= kmax; ++k) {
+            if (!Angular::Ck_kk_SR(k, Fa.kappa(), Fc.kappa())) {
+              continue;
+            }
+            if (!Angular::Ck_kk_SR(k, Fb.kappa(), Fd.kappa())) {
+              continue;
+            }
+            if (!MBPT::Sk_vwxy_SR(k, Fa, Fb, Fc, Fd)) {
+              continue;
+            }
+            const int kd = Fd.kappa();
+            const auto R_screen_exact = UnitTest::First_Order_Screen_Sk(
+              k, Fa, Fb, Fc, Fd, core, excited, qk);
+
+            const auto R_screen_operator =
+              MBPT::two_body_ME(qpiq[k], Fa, Fb, Fc, Fd);
+
+            // for if I want to test Q^k_{vwxy}
+            // const auto R_screen_operator =
+            //   Angular::neg1pow_2(Fa.twoj() - Fb.twoj()) *
+            //   Angular::Ck_kk(k, ka, kc) * Angular::Ck_kk(k, kb, kd) *
+            //   MBPT::two_body_ME(qpiq[k], Fa, Fb, Fc, Fd);
+
+            const auto eps =
+              (R_screen_operator - R_screen_exact) / R_screen_exact;
+#pragma omp critical(compare_screen_epsR_operator)
+            {
+              std::cout << Fa << " " << Fb << " " << Fc << " " << Fd << "\n";
+              std::cout << k << "  " << qk.Q(k, Fa, Fb, Fc, Fd) << "  "
+                        << R_screen_exact << "  " << R_screen_operator << " "
+                        << eps << std::endl;
+              // if (std::fabs(R_screen_exact) > 1.0e-1) {
+              if (std::abs(eps) > 1.0e-1) {
+                std::cin.get();
+              }
+              // }
+              if (R_screen_exact >= 1.0e-6) {
+                if (eps > eps_R_big) {
+                  eps_R_big = eps;
+                }
+
+              } else {
+                if (eps > eps_R_small) {
+                  eps_R_small = eps;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return {eps_R_small, eps_R_big};
+}
+
+double UnitTest::First_Order_Screen_Sk(const int &k, const DiracSpinor &v,
+                                       const DiracSpinor &w,
+                                       const DiracSpinor &x,
+                                       const DiracSpinor &y,
+                                       const std::vector<DiracSpinor> &core,
+                                       const std::vector<DiracSpinor> &excited,
+                                       const Coulomb::QkTable &qk) {
+
+  if (!MBPT::Sk_vwxy_SR(k, v, w, x, y)) {
+    return 0.0;
+  }
+
+  double out = 0.0;
+
+  const auto f = 1.0 / (2.0 * k + 1.0);
+
+  for (const auto &a : core) {
+    for (const auto &n : excited) {
+      const auto de = a.en() - n.en();
+
+      // const auto qk_vnxa = qk.Q(k, v, n, x, a);
+      // const auto qk_awny = qk.Q(k, a, w, n, y);
+
+      // const auto qk_vaxn = qk.Q(k, v, a, x, n);
+      // const auto qk_nway = qk.Q(k, n, w, a, y);
+
+      // out += (qk_vnxa * qk_awny + qk_vaxn * qk_nway) / de;
+
+      const auto qk_vnxa = qk.R(k, v, n, x, a);
+      const auto qk_awny = qk.R(k, a, w, n, y);
+
+      const auto qk_vaxn = qk.R(k, v, a, x, n);
+      const auto qk_nway = qk.R(k, n, w, a, y);
+
+      const auto Ckan = Angular::Ck_kk(k, a.kappa(), n.kappa());
+
+      out += Ckan * Ckan * (qk_vnxa * qk_awny + qk_vaxn * qk_nway) / de;
+    }
+  }
+
+  return f * out;
 }

--- a/src/Coulomb/Coulomb.tests.cpp
+++ b/src/Coulomb/Coulomb.tests.cpp
@@ -48,9 +48,9 @@ inline std::vector<double> check_ykab(const std::vector<DiracSpinor> &orbs,
 inline double check_Rkabcd(const std::vector<DiracSpinor> &orbs,
                            int max_del_n = 99);
 
-inline double check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
-                                    const MBPT::Feynman &feyn,
-                                    int max_del_n = 99);
+inline std::pair<double, double>
+check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
+                      const MBPT::Feynman &feyn, int max_del_n = 99);
 
 } // namespace UnitTest
 
@@ -713,15 +713,27 @@ TEST_CASE("Coulomb: operator form", "[Coulomb][integration][k7]") {
     const int num_points = wf.grid().num_points();
     const int num_points_subgrid = num_points / 2;
     const int stride = num_points / num_points_subgrid;
+    // const int num_points_subgrid = 800;
+    // const int stride = (wf.grid().getIndex(30.0) - wf.grid().getIndex(1.0e-4)) /
+    //                    num_points_subgrid;
+    const int i0 = wf.grid().getIndex(1.0e-6); // default i0 value
 
     MBPT::Feynman feyn =
-      MBPT::Feynman(wf.vHF(), 0, stride, num_points_subgrid, {}, 1, true);
+      MBPT::Feynman(wf.vHF(), i0, stride, num_points_subgrid, {}, 1, true);
 
-    const double eps_R = UnitTest::check_Rkabcd_operator(wf.core(), feyn, 1);
-    const double eps_R2 = UnitTest::check_Rkabcd_operator(wf.basis(), feyn, 1);
+    const std::pair<double, double> eps_R =
+      UnitTest::check_Rkabcd_operator(wf.core(), feyn, 1);
+    // const std::pair<double, double> eps_R2 =
+    //   UnitTest::check_Rkabcd_operator(wf.basis(), feyn, 1);
 
-    CHECK(std::fabs(eps_R) <= 1e-3);
-    CHECK(std::fabs(eps_R2) <= 1e-3);
+    // if R^k_{abcd} is small (R <= 1.0e-9) then they only need to agree to parts in 10^-3
+    // if R is big (R > 1.0e-9) then they need to agree to parts in 10^-9
+    const double eps_threshold_big = 1.0e-9;
+    const double eps_threshold_small = 1.0e-3;
+    CHECK(std::fabs(eps_R.first) <= eps_threshold_small);
+    // CHECK(std::fabs(eps_R2.first) <= eps_threshold_small);
+    CHECK(std::fabs(eps_R.second) <= eps_threshold_big);
+    // CHECK(std::fabs(eps_R2.second) <= eps_threshold_big);
   }
 }
 
@@ -877,10 +889,11 @@ double UnitTest::check_Rkabcd(const std::vector<DiracSpinor> &orbs,
 }
 
 //============================================================================
-double UnitTest::check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
-                                       const MBPT::Feynman &feyn,
-                                       int max_del_n) {
-  double eps_R = 0.0;
+std::pair<double, double>
+UnitTest::check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
+                                const MBPT::Feynman &feyn, int max_del_n) {
+  double eps_R_big = 0.0;
+  double eps_R_small = 0.0;
   const Coulomb::YkTable Yab(orbs);
 #pragma omp parallel for
   for (auto ia = 0ul; ia < orbs.size(); ia++) {
@@ -912,14 +925,22 @@ double UnitTest::check_Rkabcd_operator(const std::vector<DiracSpinor> &orbs,
               MBPT::two_body_ME(feyn.get_qk(k).dri(), Fa, Fb, Fc, Fd);
 
             const auto eps = std::fabs((R_exact - R_operator) / R_exact);
-#pragma omp critical(compare_epsR)
-            if (eps > eps_R) {
-              eps_R = eps;
+#pragma omp critical(compare_epsR_operator)
+            {
+              if (R_exact >= 1.0e-6) {
+                if (eps > eps_R_big) {
+                  eps_R_big = eps;
+                }
+              } else {
+                if (eps > eps_R_small) {
+                  eps_R_small = eps;
+                }
+              }
             }
           }
         }
       }
     }
   }
-  return eps_R;
+  return {eps_R_small, eps_R_big};
 }

--- a/src/HF/Breit.cpp
+++ b/src/HF/Breit.cpp
@@ -583,6 +583,18 @@ DiracSpinor Breit::Bkv_bcd_freqw(int k, int kappa_v, const DiracSpinor &Fb,
 }
 
 //==============================================================================
+
+DiracSpinor Breit::Bkv_bcd_freqw_avgd(int k, int kappa_v, const double en_v,
+                                      const DiracSpinor &Fb,
+                                      const DiracSpinor &Fc,
+                                      const DiracSpinor &Fd) const {
+  return 0.5 * (Bkv_bcd_freqw(k, kappa_v, Fb, Fc, Fd,
+                              PhysConst::alpha * abs(en_v - Fc.en())) +
+                Bkv_bcd_freqw(k, kappa_v, Fb, Fc, Fd,
+                              PhysConst::alpha * abs(Fb.en() - Fd.en())));
+}
+
+//==============================================================================
 DiracSpinor Breit::BPkv_bcd_freqw(int k, int kappa_v, const DiracSpinor &Fb,
                                   const DiracSpinor &Fc, const DiracSpinor &Fd,
                                   const double w) const {

--- a/src/HF/Breit.hpp
+++ b/src/HF/Breit.hpp
@@ -626,6 +626,20 @@ public:
   DiracSpinor Bkv_bcd_freqw(int k, int kappa_v, const DiracSpinor &Fb,
                             const DiracSpinor &Fc, const DiracSpinor &Fd,
                             const double w) const;
+  /*!
+    @brief Frequency-dependent direct Breit two-body integral averaged over frequencies w_vc and w_bd 
+
+    @details Used for including two-body frequency-dependent Breit into correlation potential
+  */
+  DiracSpinor Breit::Bkv_bcd_freqw_avgd(int k, int kappa_v, const double en_v,
+                                        const DiracSpinor &Fb,
+                                        const DiracSpinor &Fc,
+                                        const DiracSpinor &Fd) const {
+    return 0.5 * (Bkv_bcd_freqw(k, kappa_v, Fb, Fc, Fd,
+                                PhysConst::alpha * abs(en_v - Fc.en())) +
+                  Bkv_bcd_freqw(k, kappa_v, Fb, Fc, Fd,
+                                PhysConst::alpha * abs(Fb.en() - Fd.en())));
+  }
 
   /*!
     @brief Frequency-dependent exchange Breit two-body integral "right-hand-side"

--- a/src/HF/Breit.hpp
+++ b/src/HF/Breit.hpp
@@ -280,6 +280,9 @@ public:
   */
   void fill_gb(const std::vector<DiracSpinor> &basis, int t_max_k = 99);
 
+  //! Returns the scaling factor for the frequency in Breit integrals
+  double lambda_f() const { return m_lambda_f; };
+
   //! Returns the overall scaling factor
   double scale_factor() const { return m_scale; };
 
@@ -558,6 +561,7 @@ public:
     @details
     - Automatically determines frequency, based on DiracSpinors
     - Frequency-dependent analogue of @ref Bk_abcd(). See @ref Bkv_bcd_freqw().
+    - For off-shell matrix elements takes average of matrix elements evaluated w_ac and w_bd
   */
   double Bk_abcd_freqw(int k, const DiracSpinor &Fa, const DiracSpinor &Fb,
                        const DiracSpinor &Fc, const DiracSpinor &Fd) const;

--- a/src/HF/Breit.hpp
+++ b/src/HF/Breit.hpp
@@ -629,17 +629,11 @@ public:
   /*!
     @brief Frequency-dependent direct Breit two-body integral averaged over frequencies w_vc and w_bd 
 
-    @details Used for including two-body frequency-dependent Breit into correlation potential
+    @details Used for including two-body frequency-dependent Breit into correlation potential.
   */
-  DiracSpinor Breit::Bkv_bcd_freqw_avgd(int k, int kappa_v, const double en_v,
-                                        const DiracSpinor &Fb,
-                                        const DiracSpinor &Fc,
-                                        const DiracSpinor &Fd) const {
-    return 0.5 * (Bkv_bcd_freqw(k, kappa_v, Fb, Fc, Fd,
-                                PhysConst::alpha * abs(en_v - Fc.en())) +
-                  Bkv_bcd_freqw(k, kappa_v, Fb, Fc, Fd,
-                                PhysConst::alpha * abs(Fb.en() - Fd.en())));
-  }
+  DiracSpinor Bkv_bcd_freqw_avgd(int k, int kappa_v, const double en_v,
+                                 const DiracSpinor &Fb, const DiracSpinor &Fc,
+                                 const DiracSpinor &Fd) const;
 
   /*!
     @brief Frequency-dependent exchange Breit two-body integral "right-hand-side"

--- a/src/MBPT/CorrelationPotential.cpp
+++ b/src/MBPT/CorrelationPotential.cpp
@@ -302,6 +302,7 @@ GMatrix CorrelationPotential::formSigma_G(int kappa, double ev,
   if (m_includeBreit_b2) {
     // nb: do some extra work to calculate it seperately (Qk and Pk)..
     // But, since selection rules are different, it's better this way
+    const auto freq_breit = m_HF->vBreit()->lambda_f();
     fmt::print("  de[B2]  = ");
     std::cout << std::flush;
     const auto dS =

--- a/src/MBPT/CorrelationPotential.cpp
+++ b/src/MBPT/CorrelationPotential.cpp
@@ -326,7 +326,7 @@ void CorrelationPotential::setup_Feynman() {
 
   if (!m_Fy) {
     m_Fy = Feynman(m_HF, m_i0, m_stride, m_size, m_Foptions, m_n_min_core,
-                   m_includeG, true, m_fname);
+                   m_includeG, false, true, m_fname);
   }
 
   if (m_calculate_fk && !m_Fy0) {
@@ -344,14 +344,14 @@ void CorrelationPotential::setup_Feynman() {
       t_Foptions0.screening = Screening::exclude;
       t_Foptions0.hole_particle = HoleParticle::exclude;
       m_Fy0 = Feynman(m_HF, m_i0, t_stride, t_size, t_Foptions0, m_n_min_core,
-                      m_includeG, false, m_fname);
+                      m_includeG, false, false, m_fname);
 
       // Fy with screening (but no hp)
       t_FoptionsX.screening = Screening::include;
       t_FoptionsX.hole_particle = HoleParticle::exclude;
       m_FyX = m_Fy->hole_particle() ?
                 Feynman(m_HF, m_i0, t_stride, t_size, t_FoptionsX, m_n_min_core,
-                        m_includeG, false, m_fname) :
+                        m_includeG, false, false, m_fname) :
                 m_Fy;
     }
   }

--- a/src/MBPT/Feynman.cpp
+++ b/src/MBPT/Feynman.cpp
@@ -20,7 +20,7 @@ namespace MBPT {
 //==============================================================================
 Feynman::Feynman(const HF::HartreeFock *vHF, std::size_t i0, std::size_t stride,
                  std::size_t size, const FeynmanOptions &options,
-                 int n_min_core, bool include_G, bool verbose,
+                 int n_min_core, bool include_G, bool do_CI, bool verbose,
                  const std::string &ident)
   : m_HF(vHF),
     m_grid(vHF->grid_sptr()),
@@ -66,19 +66,23 @@ Feynman::Feynman(const HF::HartreeFock *vHF, std::size_t i0, std::size_t stride,
   // Construct polarisation operator
   std::string prefix = ident.substr(0, ident.find('.'));
 
-  if (prefix == "" || prefix == "false") {
-    // Don't try to read
-    form_qpiq();
-  } else {
-    std::string qpqname = prefix + ".qpq" + (m_hole_particle ? "h" : "") +
-                          (m_screen_Coulomb ? "s" : "") +
-                          (m_HF->vBreit() == nullptr ? "" : "b") +
-                          std::to_string(m_min_core_n) + ".abf";
-    const auto readOK = readwrite_qpiq(IO::FRW::read, qpqname);
-    if (!readOK) {
+  // janky but if I am constructing a Feynman object to get the screened
+  // Coulomb interaction for Sigma^2 in CI, do not need to create QPiQ
+  if (!do_CI) {
+    if (prefix == "" || prefix == "false") {
+      // Don't try to read
       form_qpiq();
-      const auto readOK2 = readwrite_qpiq(IO::FRW::write, qpqname);
-      assert(readOK2);
+    } else {
+      std::string qpqname = prefix + ".qpq" + (m_hole_particle ? "h" : "") +
+                            (m_screen_Coulomb ? "s" : "") +
+                            (m_HF->vBreit() == nullptr ? "" : "b") +
+                            std::to_string(m_min_core_n) + ".abf";
+      const auto readOK = readwrite_qpiq(IO::FRW::read, qpqname);
+      if (!readOK) {
+        form_qpiq();
+        const auto readOK2 = readwrite_qpiq(IO::FRW::write, qpqname);
+        assert(readOK2);
+      }
     }
   }
 }
@@ -810,8 +814,8 @@ ComplexRMatrix Feynman::X_screen(const ComplexRMatrix &pik,
 }
 
 //==============================================================================
-ComplexRMatrix Feynman::Q_screen(const int &k, const double &w,
-                                 const bool &hole_particle) const {
+ComplexRMatrix Feynman::Q_screen_k(const int &k, const double &w,
+                                   const bool &hole_particle) const {
   // Q_screen = -iQPiQ + (-iQPiQ)^2 + ... = [1 + iQ*Pi]^{-1} * Q*Pi*Q
 
   constexpr auto Iunit = std::complex<double>{0.0, 1.0};
@@ -819,6 +823,16 @@ ComplexRMatrix Feynman::Q_screen(const int &k, const double &w,
   const auto pik = polarisation_k(k, w, hole_particle);
   const auto X = X_screen(pik, qdri);
   return -Iunit * X * qdri * pik.drj() * qdri;
+}
+
+//==============================================================================
+std::vector<ComplexRMatrix> Feynman::Q_screen(const int &k_max, const double &w,
+                                              const bool &hole_particle) const {
+  std::vector<ComplexRMatrix> out;
+  for (int k = 0; k <= k_max; ++k) {
+    out.push_back(Q_screen_k(k, w, hole_particle));
+  }
+  return out;
 }
 
 //==============================================================================

--- a/src/MBPT/Feynman.cpp
+++ b/src/MBPT/Feynman.cpp
@@ -857,9 +857,9 @@ Feynman::dQ_screen(const int &k_max, const double &w, const bool &AO_screening,
 }
 
 //==============================================================================
-double two_body_ME(const ComplexRMatrix &G, const DiracSpinor &Fa,
-                   const DiracSpinor &Fb, const DiracSpinor &Fc,
-                   const DiracSpinor &Fd) {
+double Matrix_ME(const ComplexRMatrix &G, const DiracSpinor &Fa,
+                 const DiracSpinor &Fb, const DiracSpinor &Fc,
+                 const DiracSpinor &Fd) {
   double out = 0.0;
 
   for (auto i = 0ul; i < G.size(); ++i) {
@@ -868,6 +868,28 @@ double two_body_ME(const ComplexRMatrix &G, const DiracSpinor &Fa,
     for (auto j = 0ul; j < G.size(); ++j) {
       const auto sj = G.index_to_fullgrid(j);
       inner_sum += G(j, i) * (Fb.f(sj) * Fd.f(sj) + Fb.g(sj) * Fd.g(sj));
+    }
+    out += ((Fa.f(si) * Fc.f(si) + Fa.g(si) * Fc.g(si)) * inner_sum).real();
+  }
+
+  return out;
+}
+
+//==============================================================================
+double avg_Matrix_ME(const ComplexRMatrix &G, const ComplexRMatrix &R,
+                     const DiracSpinor &Fa, const DiracSpinor &Fb,
+                     const DiracSpinor &Fc, const DiracSpinor &Fd) {
+  assert(G.size() == R.size());
+
+  double out = 0.0;
+
+  for (auto i = 0ul; i < G.size(); ++i) {
+    const auto si = G.index_to_fullgrid(i);
+    std::complex<double> inner_sum = 0.0;
+    for (auto j = 0ul; j < G.size(); ++j) {
+      const auto sj = G.index_to_fullgrid(j);
+      inner_sum +=
+        0.5 * (G(j, i) + R(j, i)) * (Fb.f(sj) * Fd.f(sj) + Fb.g(sj) * Fd.g(sj));
     }
     out += ((Fa.f(si) * Fc.f(si) + Fa.g(si) * Fc.g(si)) * inner_sum).real();
   }

--- a/src/MBPT/Feynman.cpp
+++ b/src/MBPT/Feynman.cpp
@@ -68,7 +68,7 @@ Feynman::Feynman(const HF::HartreeFock *vHF, std::size_t i0, std::size_t stride,
 
   if (prefix == "" || prefix == "false") {
     // Don't try to read
-    // form_qpiq();
+    form_qpiq();
   } else {
     std::string qpqname = prefix + ".qpq" + (m_hole_particle ? "h" : "") +
                           (m_screen_Coulomb ? "s" : "") +

--- a/src/MBPT/Feynman.cpp
+++ b/src/MBPT/Feynman.cpp
@@ -810,6 +810,37 @@ ComplexRMatrix Feynman::X_screen(const ComplexRMatrix &pik,
 }
 
 //==============================================================================
+ComplexRMatrix Feynman::Q_screen(const int &k, const double &w,
+                                 const bool &hole_particle) const {
+  // Q_screen = -iQPiQ + (-iQPiQ)^2 + ... = [1 + iQ*Pi]^{-1} * Q*Pi*Q
+
+  constexpr auto Iunit = std::complex<double>{0.0, 1.0};
+  const auto qdri = m_qk[k];
+  const auto pik = polarisation_k(k, w, hole_particle);
+  const auto X = X_screen(pik, qdri);
+  return -Iunit * X * qdri * pik.drj() * qdri;
+}
+
+//==============================================================================
+double two_body_ME(const ComplexRMatrix &G, const DiracSpinor &Fa,
+                   const DiracSpinor &Fb, const DiracSpinor &Fc,
+                   const DiracSpinor &Fd) {
+  double out = 0.0;
+
+  for (auto i = 0ul; i < G.size(); ++i) {
+    const auto si = G.index_to_fullgrid(i);
+    std::complex<double> inner_sum = 0.0;
+    for (auto j = 0ul; j < G.size(); ++j) {
+      const auto sj = G.index_to_fullgrid(j);
+      inner_sum += (Fb.f(sj) * Fd.f(sj) + Fb.g(sj) * Fd.g(sj)) * G(i, j);
+    }
+    out += ((Fa.f(si) * Fc.f(si) + Fa.g(si) * Fc.g(si)) * inner_sum).real();
+  }
+
+  return out;
+}
+
+//==============================================================================
 GMatrix Feynman::Sigma_direct(int kv, double env,
                               std::optional<int> in_k) const {
   // If in_k is set, only calculate for single k

--- a/src/MBPT/Feynman.cpp
+++ b/src/MBPT/Feynman.cpp
@@ -889,12 +889,12 @@ double avg_Matrix_ME(const ComplexRMatrix &G, const ComplexRMatrix &R,
     for (auto j = 0ul; j < G.size(); ++j) {
       const auto sj = G.index_to_fullgrid(j);
       inner_sum +=
-        0.5 * (G(j, i) + R(j, i)) * (Fb.f(sj) * Fd.f(sj) + Fb.g(sj) * Fd.g(sj));
+        (G(j, i) + R(j, i)) * (Fb.f(sj) * Fd.f(sj) + Fb.g(sj) * Fd.g(sj));
     }
     out += ((Fa.f(si) * Fc.f(si) + Fa.g(si) * Fc.g(si)) * inner_sum).real();
   }
 
-  return out;
+  return 0.5 * out;
 }
 
 //==============================================================================

--- a/src/MBPT/Feynman.cpp
+++ b/src/MBPT/Feynman.cpp
@@ -68,7 +68,7 @@ Feynman::Feynman(const HF::HartreeFock *vHF, std::size_t i0, std::size_t stride,
 
   if (prefix == "" || prefix == "false") {
     // Don't try to read
-    form_qpiq();
+    // form_qpiq();
   } else {
     std::string qpqname = prefix + ".qpq" + (m_hole_particle ? "h" : "") +
                           (m_screen_Coulomb ? "s" : "") +

--- a/src/MBPT/Feynman.cpp
+++ b/src/MBPT/Feynman.cpp
@@ -20,7 +20,7 @@ namespace MBPT {
 //==============================================================================
 Feynman::Feynman(const HF::HartreeFock *vHF, std::size_t i0, std::size_t stride,
                  std::size_t size, const FeynmanOptions &options,
-                 int n_min_core, bool include_G, bool do_CI, bool verbose,
+                 int n_min_core, bool include_G, bool for_CI, bool verbose,
                  const std::string &ident)
   : m_HF(vHF),
     m_grid(vHF->grid_sptr()),
@@ -68,7 +68,7 @@ Feynman::Feynman(const HF::HartreeFock *vHF, std::size_t i0, std::size_t stride,
 
   // janky but if I am constructing a Feynman object to get the screened
   // Coulomb interaction for Sigma^2 in CI, do not need to create QPiQ
-  if (!do_CI) {
+  if (!for_CI) {
     if (prefix == "" || prefix == "false") {
       // Don't try to read
       form_qpiq();
@@ -604,34 +604,41 @@ ComplexRMatrix Feynman::polarisation_k(int k, std::complex<double> omega,
       const auto ck_an = Angular::Ck_kk(k, Fa.kappa(), kn);
       if (ck_an == 0.0)
         continue;
-      const double c_ang = ck_an * ck_an / double(2 * k + 1);
+      const double c_ang = ck_an * ck_an / double(2.0 * k + 1.0);
 
       ComplexGMatrix Gx_pm = green_excited(kn, ea_minus_w, Fa_hp) +
                              green_excited(kn, ea_plus_w, Fa_hp);
 
       // loop over coordinate indices.
-      // pi is symmetric in r1, r2 so is there more efficient way to do this
-      // so that I don't loop over all ri, rj?
       // pi ~ Fa^†(r1)[Gex(r1,r2,ea-w) + Gex(r1,r2,ea+w)]Fa(r2)
       for (auto i = 0ul; i < m_subgrid_points; ++i) {
         const auto si = Gx_pm.index_to_fullgrid(i);
-        for (auto j = 0ul; j <= i; ++j) {
+        pi_k(i, i) += c_ang * (Fa.f(si) * Gx_pm.ff(i, i) * Fa.f(si) +
+                               Fa.g(si) * Gx_pm.gf(i, i) * Fa.f(si) +
+                               Fa.f(si) * Gx_pm.fg(i, i) * Fa.g(si) +
+                               Fa.g(si) * Gx_pm.gg(i, i) * Fa.g(si));
+        for (auto j = 0ul; j < i; ++j) {
           const auto sj = Gx_pm.index_to_fullgrid(j);
           pi_k(i, j) += c_ang * (Fa.f(si) * Gx_pm.ff(i, j) * Fa.f(sj) +
                                  Fa.g(si) * Gx_pm.gf(i, j) * Fa.f(sj) +
                                  Fa.f(si) * Gx_pm.fg(i, j) * Fa.g(sj) +
                                  Fa.g(si) * Gx_pm.gg(i, j) * Fa.g(sj));
+
+          pi_k(j, i) += c_ang * (Fa.f(sj) * Gx_pm.ff(j, i) * Fa.f(si) +
+                                 Fa.g(sj) * Gx_pm.gf(j, i) * Fa.f(si) +
+                                 Fa.f(sj) * Gx_pm.fg(j, i) * Fa.g(si) +
+                                 Fa.g(sj) * Gx_pm.gg(j, i) * Fa.g(si));
         }
       }
     }
   }
 
   // Fill symmetric lower half:
-  for (auto i = 0ul; i < m_subgrid_points; ++i) {
-    for (auto j = 0ul; j <= i; ++j) {
-      pi_k(j, i) = pi_k(i, j);
-    }
-  }
+  // for (auto i = 0ul; i < m_subgrid_points; ++i) {
+  //   for (auto j = 0ul; j <= i; ++j) {
+  //     pi_k(j, i) = pi_k(i, j);
+  //   }
+  // }
 
   pi_k *= Iunit;
   return pi_k;
@@ -806,6 +813,7 @@ void Feynman::form_qpiq() {
 }
 
 //==============================================================================
+//! has dri (from qdri) but _NOT_ drj
 ComplexRMatrix Feynman::X_screen(const ComplexRMatrix &pik,
                                  const ComplexRMatrix &qdri) const {
   // X = [1 + i q*pi(w)]^-1
@@ -814,24 +822,37 @@ ComplexRMatrix Feynman::X_screen(const ComplexRMatrix &pik,
 }
 
 //==============================================================================
-ComplexRMatrix Feynman::Q_screen_k(const int &k, const double &w,
-                                   const bool &hole_particle) const {
-  // Q_screen = -iQPiQ + (-iQPiQ)^2 + ... = [1 + iQ*Pi]^{-1} * Q*Pi*Q
+ComplexRMatrix Feynman::dQ_screen_k(const int &k, const double &w,
+                                    const bool &AO_screening,
+                                    const bool &hole_particle) const {
+  // Q_screen = -iQPiQ + (-iQPiQ)^2 + ... = -i[1 + iQ*Pi]^{-1} * Q*Pi*Q if AO_screening == true
+  // will just calculate -iQPiQ if AO_screening == false
+  // has _BOTH_ dri and drj
 
   constexpr auto Iunit = std::complex<double>{0.0, 1.0};
-  const auto qdri = m_qk[k];
+  const auto qdri = m_qk[k].dri();
   const auto pik = polarisation_k(k, w, hole_particle);
-  const auto X = X_screen(pik, qdri);
-  return -Iunit * X * qdri * pik.drj() * qdri;
+  if (AO_screening) {
+    const auto X = X_screen(pik, qdri);
+    return -Iunit * X * qdri * pik * qdri;
+  } else {
+    return -Iunit * qdri * pik * qdri;
+  }
 }
 
 //==============================================================================
-std::vector<ComplexRMatrix> Feynman::Q_screen(const int &k_max, const double &w,
-                                              const bool &hole_particle) const {
-  std::vector<ComplexRMatrix> out;
+std::vector<ComplexRMatrix>
+Feynman::dQ_screen(const int &k_max, const double &w, const bool &AO_screening,
+                   const bool &hole_particle) const {
+  // size max_k + 1 since we calculate qpiq for k=0 up to k=kmax
+  std::vector<ComplexRMatrix> out(
+    k_max + 1, ComplexRMatrix{m_i0, m_stride, m_subgrid_points, m_grid});
+// fill each screened Coulomb interaction in parallel
+#pragma omp parallel for
   for (int k = 0; k <= k_max; ++k) {
-    out.push_back(Q_screen_k(k, w, hole_particle));
+    out[k] = dQ_screen_k(k, w, AO_screening, hole_particle);
   }
+
   return out;
 }
 
@@ -846,7 +867,7 @@ double two_body_ME(const ComplexRMatrix &G, const DiracSpinor &Fa,
     std::complex<double> inner_sum = 0.0;
     for (auto j = 0ul; j < G.size(); ++j) {
       const auto sj = G.index_to_fullgrid(j);
-      inner_sum += (Fb.f(sj) * Fd.f(sj) + Fb.g(sj) * Fd.g(sj)) * G(i, j);
+      inner_sum += G(j, i) * (Fb.f(sj) * Fd.f(sj) + Fb.g(sj) * Fd.g(sj));
     }
     out += ((Fa.f(si) * Fc.f(si) + Fa.g(si) * Fc.g(si)) * inner_sum).real();
   }

--- a/src/MBPT/Feynman.hpp
+++ b/src/MBPT/Feynman.hpp
@@ -91,7 +91,8 @@ public:
   //! ** Currently have issue: polarising deep n leads to failure?
   Feynman(const HF::HartreeFock *vHF, std::size_t i0, std::size_t stride,
           std::size_t size, const FeynmanOptions &options, int n_min_core,
-          bool include_G, bool verbose = true, const std::string &ident = "");
+          bool include_G, bool do_CI = false, bool verbose = true,
+          const std::string &ident = "");
 
   bool screening() const { return m_screen_Coulomb; }
   bool hole_particle() const { return m_hole_particle; }
@@ -132,11 +133,15 @@ public:
     return m_Vx_kappa.at(Angular::kappa_to_kindex(kappa));
   }
 
-  // Calculates only screened parts of the Coulomb interaction
+  // Calculates only screened parts of the Coulomb interaction for a particular k
   // Q_screen = -iQPiQ + (-iQPiQ)^2 + ... = [1 + iQ*Pi]^{-1} * Q*Pi*Q
   // includes left and right integration measures
-  ComplexRMatrix Q_screen(const int &k, const double &w,
-                          const bool &hole_particle) const;
+  ComplexRMatrix Q_screen_k(const int &k, const double &w,
+                            const bool &hole_particle) const;
+
+  // Calculates only screened parts of the Coulomb interaction for a all k up to k_max
+  std::vector<ComplexRMatrix> Q_screen(const int &k_max, const double &w,
+                                       const bool &hole_particle) const;
 
 private:
   // forms Qk matrices, as well as dri, drj

--- a/src/MBPT/Feynman.hpp
+++ b/src/MBPT/Feynman.hpp
@@ -132,6 +132,12 @@ public:
     return m_Vx_kappa.at(Angular::kappa_to_kindex(kappa));
   }
 
+  // Calculates only screened parts of the Coulomb interaction
+  // Q_screen = -iQPiQ + (-iQPiQ)^2 + ... = [1 + iQ*Pi]^{-1} * Q*Pi*Q
+  // includes left and right integration measures
+  ComplexRMatrix Q_screen(const int &k, const double &w,
+                          const bool &hole_particle) const;
+
 private:
   // forms Qk matrices, as well as dri, drj
   void form_qk();
@@ -206,5 +212,11 @@ public:
   Feynman(const Feynman &) = default;
   ~Feynman() = default;
 };
+
+// Calculates the matrix element <ab|G|cd> for radial (not spinor) matrix G
+// Assumes that G already includes dri and drj
+double two_body_ME(const ComplexRMatrix &G, const DiracSpinor &Fa,
+                   const DiracSpinor &Fb, const DiracSpinor &Fc,
+                   const DiracSpinor &Fd);
 
 } // namespace MBPT

--- a/src/MBPT/Feynman.hpp
+++ b/src/MBPT/Feynman.hpp
@@ -142,8 +142,8 @@ public:
 
   // Calculates only screened parts of the Coulomb interaction for a all k up to k_max
   std::vector<ComplexRMatrix> dQ_screen(const int &k_max, const double &w,
-                                       const bool &AO_screening,
-                                       const bool &hole_particle) const;
+                                        const bool &AO_screening,
+                                        const bool &hole_particle) const;
 
 private:
   // forms Qk matrices, as well as dri, drj
@@ -223,8 +223,15 @@ public:
 // Calculates the matrix element <ab|G|cd> for radial (not spinor) matrix G
 // Assumes that G already includes dri and drj
 // also assumes that the output is meant to be real; won't always be true!
-double two_body_ME(const ComplexRMatrix &G, const DiracSpinor &Fa,
-                   const DiracSpinor &Fb, const DiracSpinor &Fc,
-                   const DiracSpinor &Fd);
+double Matrix_ME(const ComplexRMatrix &G, const DiracSpinor &Fa,
+                 const DiracSpinor &Fb, const DiracSpinor &Fc,
+                 const DiracSpinor &Fd);
+
+// Calculates the _average_ matrix element 1/2 * <ab|(G + R)|cd> for radial (not spinor) matrices G and R
+// Assumes that G and R each already include dri and drj
+// also assumes that the output is meant to be real; won't always be true!
+double avg_Matrix_ME(const ComplexRMatrix &G, const ComplexRMatrix &R,
+                     const DiracSpinor &Fa, const DiracSpinor &Fb,
+                     const DiracSpinor &Fc, const DiracSpinor &Fd);
 
 } // namespace MBPT

--- a/src/MBPT/Feynman.hpp
+++ b/src/MBPT/Feynman.hpp
@@ -215,6 +215,7 @@ public:
 
 // Calculates the matrix element <ab|G|cd> for radial (not spinor) matrix G
 // Assumes that G already includes dri and drj
+// also assumes that the output is meant to be real; won't always be true!
 double two_body_ME(const ComplexRMatrix &G, const DiracSpinor &Fa,
                    const DiracSpinor &Fb, const DiracSpinor &Fc,
                    const DiracSpinor &Fd);

--- a/src/MBPT/Feynman.hpp
+++ b/src/MBPT/Feynman.hpp
@@ -91,7 +91,7 @@ public:
   //! ** Currently have issue: polarising deep n leads to failure?
   Feynman(const HF::HartreeFock *vHF, std::size_t i0, std::size_t stride,
           std::size_t size, const FeynmanOptions &options, int n_min_core,
-          bool include_G, bool do_CI = false, bool verbose = true,
+          bool include_G, bool for_CI = false, bool verbose = true,
           const std::string &ident = "");
 
   bool screening() const { return m_screen_Coulomb; }
@@ -135,12 +135,14 @@ public:
 
   // Calculates only screened parts of the Coulomb interaction for a particular k
   // Q_screen = -iQPiQ + (-iQPiQ)^2 + ... = [1 + iQ*Pi]^{-1} * Q*Pi*Q
-  // includes left and right integration measures
-  ComplexRMatrix Q_screen_k(const int &k, const double &w,
-                            const bool &hole_particle) const;
+  // has _BOTH_ dri and drj
+  ComplexRMatrix dQ_screen_k(const int &k, const double &w,
+                             const bool &AO_screening,
+                             const bool &hole_particle) const;
 
   // Calculates only screened parts of the Coulomb interaction for a all k up to k_max
-  std::vector<ComplexRMatrix> Q_screen(const int &k_max, const double &w,
+  std::vector<ComplexRMatrix> dQ_screen(const int &k_max, const double &w,
+                                       const bool &AO_screening,
                                        const bool &hole_particle) const;
 
 private:

--- a/src/MBPT/Goldstone.cpp
+++ b/src/MBPT/Goldstone.cpp
@@ -346,7 +346,10 @@ GMatrix Goldstone::dSigma_Breit2(int kappa_v, double en_v,
           const auto dele = en_v + a.en() - m.en() - n.en();
           const auto factor = fk / (f_kkjj * dele);
 
-          const auto Bkv = m_Br->Bkv_bcd(k, kappa_v, a, m, n);
+          const auto Bkv =
+            m_Br->lambda_f() == 0.0 ?
+              m_Br->Bkv_bcd(k, kappa_v, a, m, n) :
+              m_Br->Bkv_bcd_freqw_avgd(k, kappa_v, en_v, a, m, n);
           // factor of 2: correct each side of symmetric diagram
           Sd_t.add(Bkv, etak * Qkv + Pkv, 2.0 * factor);
         }
@@ -362,7 +365,10 @@ GMatrix Goldstone::dSigma_Breit2(int kappa_v, double en_v,
           const auto Pkv = m_Yeh.Pkv_bcd(k, kappa_v, n, b, a);
           const auto dele = en_v + n.en() - b.en() - a.en();
           const auto factor = fk / (f_kkjj * dele);
-          const auto Bkv = m_Br->Bkv_bcd(k, kappa_v, n, b, a);
+          const auto Bkv =
+            m_Br->lambda_f() == 0.0 ?
+              m_Br->Bkv_bcd(k, kappa_v, n, b, a) :
+              m_Br->Bkv_bcd_freqw_avgd(k, kappa_v, en_v, n, b, a);
           Sd_t.add(Bkv, etak * Qkv + Pkv, 2.0 * factor);
         }
       }

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -563,8 +563,8 @@ void FillPiMatrix(const int &max_k_Coulomb,
         // dQ_screen_Fermi[sk](kw_i, kv_i) =
         //   dQ_screen_Fermi[sk](kv_i, kw_i); // instead will just only use bottom half
       }
+      bar.update();
     }
-    bar.update();
   }
 }
 

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -387,8 +387,37 @@ double Sigma2::S_Sigma2_screen(
   const auto Ck_vx = Angular::Ck_kk(k, v.kappa(), x.kappa());
   const auto Ck_wy = Angular::Ck_kk(k, w.kappa(), y.kappa());
 
-  if (denominators == MBPT::Denominators::Fermi0) {
+  const auto ebar_v = e_bar(v.kappa(), excited);
+  const auto ebar_w = e_bar(w.kappa(), excited);
+  const auto ebar_x = e_bar(x.kappa(), excited);
+  const auto ebar_y = e_bar(y.kappa(), excited);
+
+  const auto de_vx = std::abs(ebar_v - ebar_x);
+  const auto de_wy = std::abs(ebar_w - ebar_y);
+
+  if (denominators == MBPT::Denominators::Fermi0 ||
+      (de_vx <= 0.1 && de_wy <= 0.1)) {
     return f * Ck_vx * Ck_wy * two_body_ME(Q_screen[k], v, w, x, y);
+  } else if (de_vx > 0.1 && de_wy <= 0.1) {
+    const int kvi = Angular::kappa_to_kindex(v.kappa());
+    // const int kwi = Angular::kappa_to_kindex(w.kappa());
+    const int kxi = Angular::kappa_to_kindex(x.kappa());
+    // const int kyi = Angular::kappa_to_kindex(y.kappa());
+
+    return f * Ck_vx * Ck_wy *
+           two_body_ME(
+             0.5 * (dQ_screen_Fermi[k](std::max(kvi, kxi), std::min(kvi, kxi)) +
+                    Q_screen[k]),
+             v, w, x, y);
+  } else if (de_vx <= 0.1 && de_wy > 0.1) {
+    const int kwi = Angular::kappa_to_kindex(w.kappa());
+    const int kyi = Angular::kappa_to_kindex(y.kappa());
+
+    return f * Ck_vx * Ck_wy *
+           two_body_ME(
+             0.5 * (dQ_screen_Fermi[k](std::max(kwi, kyi), std::min(kwi, kyi)) +
+                    Q_screen[k]),
+             v, w, x, y);
   } else {
     const int kvi = Angular::kappa_to_kindex(v.kappa());
     const int kwi = Angular::kappa_to_kindex(w.kappa());
@@ -396,9 +425,10 @@ double Sigma2::S_Sigma2_screen(
     const int kyi = Angular::kappa_to_kindex(y.kappa());
 
     return f * Ck_vx * Ck_wy *
-           two_body_ME(0.5 * (dQ_screen_Fermi[k](kvi, kxi) +
-                              dQ_screen_Fermi[k](kwi, kyi)),
-                       v, w, x, y);
+           two_body_ME(
+             0.5 * (dQ_screen_Fermi[k](std::max(kvi, kxi), std::min(kvi, kxi)) +
+                    dQ_screen_Fermi[k](std::max(kwi, kyi), std::min(kwi, kyi))),
+             v, w, x, y);
   }
 }
 

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -1,6 +1,7 @@
 #include "Sigma2.hpp"
 #include "Angular/include.hpp"
 #include "Coulomb/include.hpp"
+#include "MBPT/Feynman.hpp"
 #include "Wavefunction/DiracSpinor.hpp"
 
 namespace MBPT {
@@ -98,6 +99,24 @@ double Sk_vwxy(int k, const DiracSpinor &v, const DiracSpinor &w,
          S_Sigma2_c1(k, v, w, x, y, qk, core, excited, SixJ, denominators) +
          S_Sigma2_c2(k, v, w, x, y, qk, core, excited, SixJ, denominators) +
          S_Sigma2_d(k, v, w, x, y, qk, core, excited, SixJ, denominators);
+}
+
+//==============================================================================
+// this just calculates the screening Sk integrals; should be able to add the other diagrams later
+double Sk_vwxy_screened(int k, const DiracSpinor &v, const DiracSpinor &w,
+                        const DiracSpinor &x, const DiracSpinor &y,
+                        const Coulomb::QkTable &qk,
+                        const std::vector<DiracSpinor> &core,
+                        const std::vector<DiracSpinor> &excited,
+                        const Angular::SixJTable &SixJ,
+                        Denominators denominators, const Feynman &feyn) {
+  using namespace Sigma2;
+
+  if (!Sk_vwxy_SR(k, v, w, x, y))
+    return 0.0;
+
+  // should add back in the other diagrams as well
+  return S_Sigma2_screen(k, v, w, x, y, denominators, feyn);
 }
 
 //==============================================================================
@@ -349,6 +368,34 @@ double Sigma2::S_Sigma2_d(int k, const DiracSpinor &v, const DiracSpinor &w,
 }
 
 //==============================================================================
+double Sigma2::S_Sigma2_screen(int k, const DiracSpinor &v,
+                               const DiracSpinor &w, const DiracSpinor &x,
+                               const DiracSpinor &y, Denominators denominators,
+                               const Feynman &feyn) {
+
+  // overall selectrion rule tested outside
+
+  // const auto v0 = e_bar(v.kappa(), excited);
+  // const auto w0 = e_bar(w.kappa(), excited);
+  // const auto x0 = e_bar(x.kappa(), excited);
+  // const auto y0 = e_bar(y.kappa(), excited);
+  // const auto e0 = DiracSpinor::min_En(excited);
+
+  // Here, "Fermi0" cancellation doesn't happen
+  // So, Fermi and Fermi0 are the same
+
+  const double w_xv = x.en() - v.en();
+  const double w_wy = w.en() - y.en();
+
+  const auto qpiq =
+    denominators == Denominators::RS ?
+      0.5 * (feyn.Q_screen(k, w_xv, false) + feyn.Q_screen(k, w_wy, false)) :
+      feyn.Q_screen(k, 0.0, false);
+
+  return two_body_ME(qpiq, v, w, x, y);
+}
+
+//==============================================================================
 Coulomb::LkTable calculate_Sk(
   const std::string &filename, const std::vector<DiracSpinor> &external,
   const std::vector<DiracSpinor> &core, const std::vector<DiracSpinor> &excited,
@@ -366,6 +413,52 @@ Coulomb::LkTable calculate_Sk(
                                const DiracSpinor &w, const DiracSpinor &x,
                                const DiracSpinor &y) {
     return MBPT::Sk_vwxy(k, v, w, x, y, qk, core, excited, sjt, denominators);
+  };
+  const auto Sk_selection_rule = [&](int k, const DiracSpinor &v,
+                                     const DiracSpinor &w, const DiracSpinor &x,
+                                     const DiracSpinor &y) {
+    return exclude_wrong_parity_box ? Coulomb::Qk_abcd_SR(k, v, w, x, y) :
+                                      MBPT::Sk_vwxy_SR(k, v, w, x, y);
+  };
+
+  // Try to read from disk (may already have calculated Qk)
+  Sk.read(filename);
+
+  const auto existing = Sk.count();
+  {
+    if (!no_new_integrals)
+      Sk.fill(external, Sk_function, Sk_selection_rule, max_k);
+
+    const auto total = Sk.count();
+    assert(total >= existing);
+    const auto new_integrals = total - existing;
+    std::cout << "Calculated " << new_integrals << " new MBPT integrals\n";
+    if (new_integrals > 0) {
+      Sk.write(filename);
+    }
+  }
+  std::cout << "\n" << std::flush;
+  return Sk;
+}
+
+Coulomb::LkTable calculate_Sk_screened(
+  const std::string &filename, const std::vector<DiracSpinor> &external,
+  const std::vector<DiracSpinor> &core, const std::vector<DiracSpinor> &excited,
+  const Coulomb::QkTable &qk, int max_k, bool exclude_wrong_parity_box,
+  Denominators denominators, MBPT::Feynman feyn, bool no_new_integrals) {
+
+  Coulomb::LkTable Sk;
+
+  const auto max_twoj =
+    std::max({DiracSpinor::max_tj(excited), DiracSpinor::max_tj(core),
+              DiracSpinor::max_tj(external)});
+  Angular::SixJTable sjt(max_twoj);
+
+  const auto Sk_function = [&](int k, const DiracSpinor &v,
+                               const DiracSpinor &w, const DiracSpinor &x,
+                               const DiracSpinor &y) {
+    return MBPT::Sk_vwxy_screened(k, v, w, x, y, qk, core, excited, sjt,
+                                  denominators, feyn);
   };
   const auto Sk_selection_rule = [&](int k, const DiracSpinor &v,
                                      const DiracSpinor &w, const DiracSpinor &x,

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -330,7 +330,7 @@ double Sigma2::S_Sigma2_d(int k, const DiracSpinor &v, const DiracSpinor &w,
   // Here, "Fermi0" cancellation doesn't happen
   // So, Fermi and Fermi0 are the same
   const auto de_vw = denominators == Denominators::Fermi0 ?
-                       2.0 * e0 :
+                       -2.0 * e0 :
                      denominators == Denominators::Fermi ?
                        -0.5 * (v0 + w0 + x0 + y0) :
                        -0.5 * (v.en() + w.en() + x.en() + y.en());

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -110,13 +110,14 @@ double Sk_vwxy_screened(int k, const DiracSpinor &v, const DiracSpinor &w,
                         const std::vector<DiracSpinor> &excited,
                         const Angular::SixJTable &SixJ,
                         Denominators denominators,
-                        const std::vector<MBPT::ComplexRMatrix> &Q_screen) {
+                        const std::vector<MBPT::ComplexRMatrix> &dQ_screen) {
   using namespace Sigma2;
 
-  if (!Sk_vwxy_SR(k, v, w, x, y))
+  if (!Sk_vwxy_SR(k, v, w, x, y)) {
     return 0.0;
+  }
 
-  return S_Sigma2_screen(k, v, w, x, y, denominators, Q_screen) +
+  return S_Sigma2_screen(k, v, w, x, y, denominators, dQ_screen) +
          S_Sigma2_ab(k, v, w, x, y, qk, core, excited, SixJ, denominators,
                      true) +
          S_Sigma2_c1(k, v, w, x, y, qk, core, excited, SixJ, denominators) +
@@ -396,11 +397,14 @@ Sigma2::S_Sigma2_screen(int k, const DiracSpinor &v, const DiracSpinor &w,
   // const double w_wy = w.en() - y.en();
 
   // const auto qpiq = denominators == Denominators::RS ?
-  //                     0.5 * (feyn.Q_screen_k(k, w_xv, false) +
-  //                            feyn.Q_screen_k(k, w_wy, false)) :
-  //                     feyn.Q_screen_k(k, 0.0, false);
+  //                     0.5 * (feyn.dQ_screen_k(k, w_xv, false) +
+  //                            feyn.dQ_screen_k(k, w_wy, false)) :
+  //                     feyn.dQ_screen_k(k, 0.0, false);
+  const auto f = Angular::neg1pow_2(2 * k + v.twoj() - w.twoj());
+  const auto Ck_vx = Angular::Ck_kk(k, v.kappa(), x.kappa());
+  const auto Ck_wy = Angular::Ck_kk(k, w.kappa(), y.kappa());
 
-  return two_body_ME(Q_screen[k], v, w, x, y);
+  return f * Ck_vx * Ck_wy * two_body_ME(Q_screen[k], v, w, x, y);
 }
 
 //==============================================================================

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -102,20 +102,21 @@ double Sk_vwxy(int k, const DiracSpinor &v, const DiracSpinor &w,
 }
 
 //==============================================================================
-// this just calculates the screening Sk integrals; should be able to add the other diagrams later
+// this just calculates the screening Sk integrals
 double Sk_vwxy_screened(int k, const DiracSpinor &v, const DiracSpinor &w,
                         const DiracSpinor &x, const DiracSpinor &y,
                         const Coulomb::QkTable &qk,
                         const std::vector<DiracSpinor> &core,
                         const std::vector<DiracSpinor> &excited,
                         const Angular::SixJTable &SixJ,
-                        Denominators denominators, const Feynman &feyn) {
+                        Denominators denominators,
+                        const std::vector<MBPT::ComplexRMatrix> &Q_screen) {
   using namespace Sigma2;
 
   if (!Sk_vwxy_SR(k, v, w, x, y))
     return 0.0;
 
-  return S_Sigma2_screen(k, v, w, x, y, denominators, feyn) +
+  return S_Sigma2_screen(k, v, w, x, y, denominators, Q_screen) +
          S_Sigma2_ab(k, v, w, x, y, qk, core, excited, SixJ, denominators,
                      true) +
          S_Sigma2_c1(k, v, w, x, y, qk, core, excited, SixJ, denominators) +
@@ -374,10 +375,11 @@ double Sigma2::S_Sigma2_d(int k, const DiracSpinor &v, const DiracSpinor &w,
 }
 
 //==============================================================================
-double Sigma2::S_Sigma2_screen(int k, const DiracSpinor &v,
-                               const DiracSpinor &w, const DiracSpinor &x,
-                               const DiracSpinor &y, Denominators denominators,
-                               const Feynman &feyn) {
+double
+Sigma2::S_Sigma2_screen(int k, const DiracSpinor &v, const DiracSpinor &w,
+                        const DiracSpinor &x, const DiracSpinor &y,
+                        Denominators denominators,
+                        const std::vector<MBPT::ComplexRMatrix> &Q_screen) {
 
   // overall selectrion rule tested outside
 
@@ -390,15 +392,15 @@ double Sigma2::S_Sigma2_screen(int k, const DiracSpinor &v,
   // Here, "Fermi0" cancellation doesn't happen
   // So, Fermi and Fermi0 are the same
 
-  const double w_xv = x.en() - v.en();
-  const double w_wy = w.en() - y.en();
+  // const double w_xv = x.en() - v.en();
+  // const double w_wy = w.en() - y.en();
 
-  const auto qpiq =
-    denominators == Denominators::RS ?
-      0.5 * (feyn.Q_screen(k, w_xv, false) + feyn.Q_screen(k, w_wy, false)) :
-      feyn.Q_screen(k, 0.0, false);
+  // const auto qpiq = denominators == Denominators::RS ?
+  //                     0.5 * (feyn.Q_screen_k(k, w_xv, false) +
+  //                            feyn.Q_screen_k(k, w_wy, false)) :
+  //                     feyn.Q_screen_k(k, 0.0, false);
 
-  return two_body_ME(qpiq, v, w, x, y);
+  return two_body_ME(Q_screen[k], v, w, x, y);
 }
 
 //==============================================================================
@@ -451,7 +453,8 @@ Coulomb::LkTable calculate_Sk_screened(
   const std::string &filename, const std::vector<DiracSpinor> &external,
   const std::vector<DiracSpinor> &core, const std::vector<DiracSpinor> &excited,
   const Coulomb::QkTable &qk, int max_k, bool exclude_wrong_parity_box,
-  Denominators denominators, MBPT::Feynman feyn, bool no_new_integrals) {
+  Denominators denominators, const std::vector<MBPT::ComplexRMatrix> &Q_screen,
+  bool no_new_integrals) {
 
   Coulomb::LkTable Sk;
 
@@ -464,7 +467,7 @@ Coulomb::LkTable calculate_Sk_screened(
                                const DiracSpinor &w, const DiracSpinor &x,
                                const DiracSpinor &y) {
     return MBPT::Sk_vwxy_screened(k, v, w, x, y, qk, core, excited, sjt,
-                                  denominators, feyn);
+                                  denominators, Q_screen);
   };
   const auto Sk_selection_rule = [&](int k, const DiracSpinor &v,
                                      const DiracSpinor &w, const DiracSpinor &x,

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -397,40 +397,47 @@ double Sigma2::S_Sigma2_screen(
 
   if (denominators == MBPT::Denominators::Fermi0 ||
       (de_vx <= 0.1 && de_wy <= 0.1)) {
-    return f * Ck_vx * Ck_wy * two_body_ME(Q_screen[k], v, w, x, y);
+    return f * Ck_vx * Ck_wy * Matrix_ME(Q_screen[k], v, w, x, y);
   } else if (de_vx > 0.1 && de_wy <= 0.1) {
     const int kvi = Angular::kappa_to_kindex(v.kappa());
-    // const int kwi = Angular::kappa_to_kindex(w.kappa());
     const int kxi = Angular::kappa_to_kindex(x.kappa());
-    // const int kyi = Angular::kappa_to_kindex(y.kappa());
+    const std::pair<int, int> kivx_pair = {std::max(kvi, kxi),
+                                           std::min(kvi, kxi)};
+    const int kivx_max = kivx_pair.first;
+    const int kivx_min = kivx_pair.second;
 
-    return f * Ck_vx * Ck_wy * 0.5 *
-           (two_body_ME(
-              dQ_screen_Fermi[k](std::max(kvi, kxi), std::min(kvi, kxi)), v, w,
-              x, y) +
-            two_body_ME(Q_screen[k], v, w, x, y));
+    return f * Ck_vx * Ck_wy *
+           avg_Matrix_ME(dQ_screen_Fermi[k](kivx_max, kivx_min), Q_screen[k], v,
+                         w, x, y);
   } else if (de_vx <= 0.1 && de_wy > 0.1) {
     const int kwi = Angular::kappa_to_kindex(w.kappa());
     const int kyi = Angular::kappa_to_kindex(y.kappa());
 
-    return f * Ck_vx * Ck_wy * 0.5 *
-           (two_body_ME(
-              dQ_screen_Fermi[k](std::max(kwi, kyi), std::min(kwi, kyi)), v, w,
-              x, y) +
-            two_body_ME(Q_screen[k], v, w, x, y));
+    const std::pair<int, int> kiwy_pair = {std::max(kwi, kyi),
+                                           std::min(kwi, kyi)};
+    const int kiwy_max = kiwy_pair.first;
+    const int kiwy_min = kiwy_pair.second;
+
+    return f * Ck_vx * Ck_wy *
+           avg_Matrix_ME(dQ_screen_Fermi[k](kiwy_max, kiwy_min), Q_screen[k], v,
+                         w, x, y);
   } else {
     const int kvi = Angular::kappa_to_kindex(v.kappa());
     const int kwi = Angular::kappa_to_kindex(w.kappa());
     const int kxi = Angular::kappa_to_kindex(x.kappa());
     const int kyi = Angular::kappa_to_kindex(y.kappa());
+    const std::pair<int, int> kivx_pair = {std::max(kvi, kxi),
+                                           std::min(kvi, kxi)};
+    const std::pair<int, int> kiwy_pair = {std::max(kwi, kyi),
+                                           std::min(kwi, kyi)};
+    const int kivx_max = kivx_pair.first;
+    const int kivx_min = kivx_pair.second;
+    const int kiwy_max = kiwy_pair.first;
+    const int kiwy_min = kiwy_pair.second;
 
-    return f * Ck_vx * Ck_wy * 0.5 *
-           (two_body_ME(
-              dQ_screen_Fermi[k](std::max(kvi, kxi), std::min(kvi, kxi)), v, w,
-              x, y) +
-            two_body_ME(
-              dQ_screen_Fermi[k](std::max(kwi, kyi), std::min(kwi, kyi)), v, w,
-              x, y));
+    return f * Ck_vx * Ck_wy *
+           avg_Matrix_ME(dQ_screen_Fermi[k](kivx_max, kivx_min),
+                         dQ_screen_Fermi[k](kiwy_max, kiwy_min), v, w, x, y);
   }
 }
 

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -115,7 +115,6 @@ double Sk_vwxy_screened(int k, const DiracSpinor &v, const DiracSpinor &w,
   if (!Sk_vwxy_SR(k, v, w, x, y))
     return 0.0;
 
-  // should add back in the other diagrams as well
   return S_Sigma2_screen(k, v, w, x, y, denominators, feyn) +
          S_Sigma2_ab(k, v, w, x, y, qk, core, excited, SixJ, denominators,
                      true) +

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -103,21 +103,21 @@ double Sk_vwxy(int k, const DiracSpinor &v, const DiracSpinor &w,
 
 //==============================================================================
 // this just calculates the screening Sk integrals
-double Sk_vwxy_screened(int k, const DiracSpinor &v, const DiracSpinor &w,
-                        const DiracSpinor &x, const DiracSpinor &y,
-                        const Coulomb::QkTable &qk,
-                        const std::vector<DiracSpinor> &core,
-                        const std::vector<DiracSpinor> &excited,
-                        const Angular::SixJTable &SixJ,
-                        Denominators denominators,
-                        const std::vector<MBPT::ComplexRMatrix> &dQ_screen) {
+double Sk_vwxy_screened(
+  int k, const DiracSpinor &v, const DiracSpinor &w, const DiracSpinor &x,
+  const DiracSpinor &y, const Coulomb::QkTable &qk,
+  const std::vector<DiracSpinor> &core, const std::vector<DiracSpinor> &excited,
+  const Angular::SixJTable &SixJ, Denominators denominators,
+  const std::vector<MBPT::ComplexRMatrix> &dQ_screen,
+  const std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> &dQ_screen_Fermi) {
   using namespace Sigma2;
 
   if (!Sk_vwxy_SR(k, v, w, x, y)) {
     return 0.0;
   }
 
-  return S_Sigma2_screen(k, v, w, x, y, denominators, dQ_screen) +
+  return S_Sigma2_screen(k, v, w, x, y, excited, denominators, dQ_screen,
+                         dQ_screen_Fermi) +
          S_Sigma2_ab(k, v, w, x, y, qk, core, excited, SixJ, denominators,
                      true) +
          S_Sigma2_c1(k, v, w, x, y, qk, core, excited, SixJ, denominators) +
@@ -376,35 +376,30 @@ double Sigma2::S_Sigma2_d(int k, const DiracSpinor &v, const DiracSpinor &w,
 }
 
 //==============================================================================
-double
-Sigma2::S_Sigma2_screen(int k, const DiracSpinor &v, const DiracSpinor &w,
-                        const DiracSpinor &x, const DiracSpinor &y,
-                        Denominators denominators,
-                        const std::vector<MBPT::ComplexRMatrix> &Q_screen) {
+double Sigma2::S_Sigma2_screen(
+  int k, const DiracSpinor &v, const DiracSpinor &w, const DiracSpinor &x,
+  const DiracSpinor &y, const std::vector<DiracSpinor> &excited,
+  Denominators denominators, const std::vector<MBPT::ComplexRMatrix> &Q_screen,
+  const std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> &dQ_screen_Fermi) {
 
   // overall selectrion rule tested outside
-
-  // const auto v0 = e_bar(v.kappa(), excited);
-  // const auto w0 = e_bar(w.kappa(), excited);
-  // const auto x0 = e_bar(x.kappa(), excited);
-  // const auto y0 = e_bar(y.kappa(), excited);
-  // const auto e0 = DiracSpinor::min_En(excited);
-
-  // Here, "Fermi0" cancellation doesn't happen
-  // So, Fermi and Fermi0 are the same
-
-  // const double w_xv = x.en() - v.en();
-  // const double w_wy = w.en() - y.en();
-
-  // const auto qpiq = denominators == Denominators::RS ?
-  //                     0.5 * (feyn.dQ_screen_k(k, w_xv, false) +
-  //                            feyn.dQ_screen_k(k, w_wy, false)) :
-  //                     feyn.dQ_screen_k(k, 0.0, false);
   const auto f = Angular::neg1pow_2(2 * k + v.twoj() - w.twoj());
   const auto Ck_vx = Angular::Ck_kk(k, v.kappa(), x.kappa());
   const auto Ck_wy = Angular::Ck_kk(k, w.kappa(), y.kappa());
 
-  return f * Ck_vx * Ck_wy * two_body_ME(Q_screen[k], v, w, x, y);
+  if (denominators == MBPT::Denominators::Fermi0) {
+    return f * Ck_vx * Ck_wy * two_body_ME(Q_screen[k], v, w, x, y);
+  } else {
+    const int kvi = Angular::kappa_to_kindex(v.kappa());
+    const int kwi = Angular::kappa_to_kindex(w.kappa());
+    const int kxi = Angular::kappa_to_kindex(x.kappa());
+    const int kyi = Angular::kappa_to_kindex(y.kappa());
+
+    return f * Ck_vx * Ck_wy *
+           two_body_ME(0.5 * (dQ_screen_Fermi[k](kvi, kxi) +
+                              dQ_screen_Fermi[k](kwi, kyi)),
+                       v, w, x, y);
+  }
 }
 
 //==============================================================================
@@ -458,6 +453,7 @@ Coulomb::LkTable calculate_Sk_screened(
   const std::vector<DiracSpinor> &core, const std::vector<DiracSpinor> &excited,
   const Coulomb::QkTable &qk, int max_k, bool exclude_wrong_parity_box,
   Denominators denominators, const std::vector<MBPT::ComplexRMatrix> &Q_screen,
+  const std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> &dQ_screen_Fermi,
   bool no_new_integrals) {
 
   Coulomb::LkTable Sk;
@@ -471,7 +467,7 @@ Coulomb::LkTable calculate_Sk_screened(
                                const DiracSpinor &w, const DiracSpinor &x,
                                const DiracSpinor &y) {
     return MBPT::Sk_vwxy_screened(k, v, w, x, y, qk, core, excited, sjt,
-                                  denominators, Q_screen);
+                                  denominators, Q_screen, dQ_screen_Fermi);
   };
   const auto Sk_selection_rule = [&](int k, const DiracSpinor &v,
                                      const DiracSpinor &w, const DiracSpinor &x,

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -162,7 +162,7 @@ double Sigma2::S_Sigma2_ab(int k, const DiracSpinor &v, const DiracSpinor &w,
       const auto qk_awny = qk.Q(k, a, w, n, y);
       const auto pk_awny = qk.P(k, a, w, n, y, &SixJ);
       // _DON'T_ include diagram a1 if we are screening, since this would overcount
-      const auto wk_awny = (screen == true) ? pk_awny : qk_awny + pk_awny;
+      const auto wk_awny = screen ? pk_awny : qk_awny + pk_awny;
 
       // diagrams a1, a2, a3:
       sum += (qk_vnxa * wk_awny + pk_vnxa * qk_awny) / de;
@@ -172,7 +172,8 @@ double Sigma2::S_Sigma2_ab(int k, const DiracSpinor &v, const DiracSpinor &w,
       const auto pk_vaxn = v == x ? pk_vnxa : qk.P(k, v, a, x, n, &SixJ);
       const auto qk_nway = qk_awny;
       const auto pk_nway = w == y ? pk_awny : qk.P(k, n, w, a, y, &SixJ);
-      const auto wk_nway = (screen == true) ? pk_nway : qk_nway + pk_nway;
+      // again, we don't include diagram b1 if we are screening
+      const auto wk_nway = screen ? pk_nway : qk_nway + pk_nway;
 
       // diagrams b1, b2, b3:
       sum += (qk_vaxn * wk_nway + pk_vaxn * qk_nway) / de;

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -116,7 +116,12 @@ double Sk_vwxy_screened(int k, const DiracSpinor &v, const DiracSpinor &w,
     return 0.0;
 
   // should add back in the other diagrams as well
-  return S_Sigma2_screen(k, v, w, x, y, denominators, feyn);
+  return S_Sigma2_screen(k, v, w, x, y, denominators, feyn) +
+         S_Sigma2_ab(k, v, w, x, y, qk, core, excited, SixJ, denominators,
+                     true) +
+         S_Sigma2_c1(k, v, w, x, y, qk, core, excited, SixJ, denominators) +
+         S_Sigma2_c2(k, v, w, x, y, qk, core, excited, SixJ, denominators) +
+         S_Sigma2_d(k, v, w, x, y, qk, core, excited, SixJ, denominators);
 }
 
 //==============================================================================
@@ -128,7 +133,7 @@ double Sigma2::S_Sigma2_ab(int k, const DiracSpinor &v, const DiracSpinor &w,
                            const std::vector<DiracSpinor> &core,
                            const std::vector<DiracSpinor> &excited,
                            const Angular::SixJTable &SixJ,
-                           Denominators denominators) {
+                           Denominators denominators, const bool &screen) {
 
   // overall selectrion rule tested outside
 
@@ -157,7 +162,8 @@ double Sigma2::S_Sigma2_ab(int k, const DiracSpinor &v, const DiracSpinor &w,
 
       const auto qk_awny = qk.Q(k, a, w, n, y);
       const auto pk_awny = qk.P(k, a, w, n, y, &SixJ);
-      const auto wk_awny = qk_awny + pk_awny;
+      // _DON'T_ include diagram a1 if we are screening, since this would overcount
+      const auto wk_awny = (screen == true) ? pk_awny : qk_awny + pk_awny;
 
       // diagrams a1, a2, a3:
       sum += (qk_vnxa * wk_awny + pk_vnxa * qk_awny) / de;
@@ -167,7 +173,7 @@ double Sigma2::S_Sigma2_ab(int k, const DiracSpinor &v, const DiracSpinor &w,
       const auto pk_vaxn = v == x ? pk_vnxa : qk.P(k, v, a, x, n, &SixJ);
       const auto qk_nway = qk_awny;
       const auto pk_nway = w == y ? pk_awny : qk.P(k, n, w, a, y, &SixJ);
-      const auto wk_nway = qk_nway + pk_nway;
+      const auto wk_nway = (screen == true) ? pk_nway : qk_nway + pk_nway;
 
       // diagrams b1, b2, b3:
       sum += (qk_vaxn * wk_nway + pk_vaxn * qk_nway) / de;

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -526,4 +526,46 @@ Coulomb::LkTable calculate_Sk_screened(
   return Sk;
 }
 
+// we only fill in lower half of the matrix to save on memory allocation
+void FillPiMatrix(const int &max_k_Coulomb,
+                  const std::vector<DiracSpinor> &cis2_basis,
+                  const std::string &cis2_basis_str,
+                  const std::vector<int> &kappai_list, const Feynman &feyn,
+                  std::vector<LinAlg::Matrix<ComplexRMatrix>> &PiMatrix) {
+
+  qip::ProgressBar bar(kappai_list.size(), true);
+
+#pragma omp parallel for collapse(2)
+  for (int kv_i = kappai_list[0]; kv_i < kappai_list.back(); kv_i++) {
+    for (int kw_i = 0; kw_i < kv_i; kw_i++) {
+      auto kw = Angular::kindex_to_kappa(kw_i);
+      auto kv = Angular::kindex_to_kappa(kv_i);
+      double ebar_v = MBPT::e_bar(kv, cis2_basis);
+      double ebar_w = MBPT::e_bar(kw, cis2_basis);
+      double de = std::abs(ebar_v - ebar_w);
+      for (int k = 0; k <= max_k_Coulomb; k++) {
+        std::size_t sk = k;
+
+        // do not bother calculating the polarisation operator
+        // if the matrix element <vx|dQ|wy> will be zero
+        if (Angular::Ck_kk(k, kv, kw) == 0.0) {
+          continue;
+        }
+
+        // if de ~= 0.0, can just use the w = 0.0 matrix element we have evaluated outside
+        if (std::abs(de) <= 0.1) {
+          // dQ_screen_Fermi[sk](kv_i, kw_i) = dQ_screen[k];
+          continue;
+        }
+
+        PiMatrix[sk](kv_i, kw_i) = feyn.dQ_screen_k(k, de, true, true);
+        // fill symmetric lower half of matrix
+        // dQ_screen_Fermi[sk](kw_i, kv_i) =
+        //   dQ_screen_Fermi[sk](kv_i, kw_i); // instead will just only use bottom half
+      }
+    }
+    bar.update();
+  }
+}
+
 } // namespace MBPT

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -401,10 +401,8 @@ double Sigma2::S_Sigma2_screen(
   } else if (de_vx > 0.1 && de_wy <= 0.1) {
     const int kvi = Angular::kappa_to_kindex(v.kappa());
     const int kxi = Angular::kappa_to_kindex(x.kappa());
-    const std::pair<int, int> kivx_pair = {std::max(kvi, kxi),
-                                           std::min(kvi, kxi)};
-    const int kivx_max = kivx_pair.first;
-    const int kivx_min = kivx_pair.second;
+    const auto [kivx_min, kivx_max] =
+      std::pair{std::min(kvi, kxi), std::max(kvi, kxi)};
 
     return f * Ck_vx * Ck_wy *
            avg_Matrix_ME(dQ_screen_Fermi[k](kivx_max, kivx_min), Q_screen[k], v,
@@ -412,11 +410,8 @@ double Sigma2::S_Sigma2_screen(
   } else if (de_vx <= 0.1 && de_wy > 0.1) {
     const int kwi = Angular::kappa_to_kindex(w.kappa());
     const int kyi = Angular::kappa_to_kindex(y.kappa());
-
-    const std::pair<int, int> kiwy_pair = {std::max(kwi, kyi),
-                                           std::min(kwi, kyi)};
-    const int kiwy_max = kiwy_pair.first;
-    const int kiwy_min = kiwy_pair.second;
+    const auto [kiwy_min, kiwy_max] =
+      std::pair{std::min(kwi, kyi), std::max(kwi, kyi)};
 
     return f * Ck_vx * Ck_wy *
            avg_Matrix_ME(dQ_screen_Fermi[k](kiwy_max, kiwy_min), Q_screen[k], v,
@@ -426,14 +421,10 @@ double Sigma2::S_Sigma2_screen(
     const int kwi = Angular::kappa_to_kindex(w.kappa());
     const int kxi = Angular::kappa_to_kindex(x.kappa());
     const int kyi = Angular::kappa_to_kindex(y.kappa());
-    const std::pair<int, int> kivx_pair = {std::max(kvi, kxi),
-                                           std::min(kvi, kxi)};
-    const std::pair<int, int> kiwy_pair = {std::max(kwi, kyi),
-                                           std::min(kwi, kyi)};
-    const int kivx_max = kivx_pair.first;
-    const int kivx_min = kivx_pair.second;
-    const int kiwy_max = kiwy_pair.first;
-    const int kiwy_min = kiwy_pair.second;
+    const auto [kivx_min, kivx_max] =
+      std::pair{std::min(kvi, kxi), std::max(kvi, kxi)};
+    const auto [kiwy_min, kiwy_max] =
+      std::pair{std::min(kwi, kyi), std::max(kwi, kyi)};
 
     return f * Ck_vx * Ck_wy *
            avg_Matrix_ME(dQ_screen_Fermi[k](kivx_max, kivx_min),

--- a/src/MBPT/Sigma2.cpp
+++ b/src/MBPT/Sigma2.cpp
@@ -404,31 +404,33 @@ double Sigma2::S_Sigma2_screen(
     const int kxi = Angular::kappa_to_kindex(x.kappa());
     // const int kyi = Angular::kappa_to_kindex(y.kappa());
 
-    return f * Ck_vx * Ck_wy *
-           two_body_ME(
-             0.5 * (dQ_screen_Fermi[k](std::max(kvi, kxi), std::min(kvi, kxi)) +
-                    Q_screen[k]),
-             v, w, x, y);
+    return f * Ck_vx * Ck_wy * 0.5 *
+           (two_body_ME(
+              dQ_screen_Fermi[k](std::max(kvi, kxi), std::min(kvi, kxi)), v, w,
+              x, y) +
+            two_body_ME(Q_screen[k], v, w, x, y));
   } else if (de_vx <= 0.1 && de_wy > 0.1) {
     const int kwi = Angular::kappa_to_kindex(w.kappa());
     const int kyi = Angular::kappa_to_kindex(y.kappa());
 
-    return f * Ck_vx * Ck_wy *
-           two_body_ME(
-             0.5 * (dQ_screen_Fermi[k](std::max(kwi, kyi), std::min(kwi, kyi)) +
-                    Q_screen[k]),
-             v, w, x, y);
+    return f * Ck_vx * Ck_wy * 0.5 *
+           (two_body_ME(
+              dQ_screen_Fermi[k](std::max(kwi, kyi), std::min(kwi, kyi)), v, w,
+              x, y) +
+            two_body_ME(Q_screen[k], v, w, x, y));
   } else {
     const int kvi = Angular::kappa_to_kindex(v.kappa());
     const int kwi = Angular::kappa_to_kindex(w.kappa());
     const int kxi = Angular::kappa_to_kindex(x.kappa());
     const int kyi = Angular::kappa_to_kindex(y.kappa());
 
-    return f * Ck_vx * Ck_wy *
-           two_body_ME(
-             0.5 * (dQ_screen_Fermi[k](std::max(kvi, kxi), std::min(kvi, kxi)) +
-                    dQ_screen_Fermi[k](std::max(kwi, kyi), std::min(kwi, kyi))),
-             v, w, x, y);
+    return f * Ck_vx * Ck_wy * 0.5 *
+           (two_body_ME(
+              dQ_screen_Fermi[k](std::max(kvi, kxi), std::min(kvi, kxi)), v, w,
+              x, y) +
+            two_body_ME(
+              dQ_screen_Fermi[k](std::max(kwi, kyi), std::min(kwi, kyi)), v, w,
+              x, y));
   }
 }
 

--- a/src/MBPT/Sigma2.hpp
+++ b/src/MBPT/Sigma2.hpp
@@ -235,7 +235,8 @@ double e_bar(int kappa_v, const std::vector<DiracSpinor> &excited);
   const std::string &filename, const std::vector<DiracSpinor> &external,
   const std::vector<DiracSpinor> &core, const std::vector<DiracSpinor> &excited,
   const Coulomb::QkTable &qk, int max_k, bool exclude_wrong_parity_box,
-  Denominators denominators, MBPT::Feynman feyn, bool no_new_integrals = false);
+  Denominators denominators, const std::vector<MBPT::ComplexRMatrix> &Q_screen,
+  bool no_new_integrals = false);
 
 //==============================================================================
 //==============================================================================
@@ -350,7 +351,8 @@ double S_Sigma2_d(int k, const DiracSpinor &v, const DiracSpinor &w,
 */
 double S_Sigma2_screen(int k, const DiracSpinor &v, const DiracSpinor &w,
                        const DiracSpinor &x, const DiracSpinor &y,
-                       Denominators denominators, const Feynman &feyn);
+                       Denominators denominators,
+                       const std::vector<MBPT::ComplexRMatrix> &Q_screen);
 
 } // namespace Sigma2
 

--- a/src/MBPT/Sigma2.hpp
+++ b/src/MBPT/Sigma2.hpp
@@ -264,7 +264,8 @@ double S_Sigma2_ab(int k, const DiracSpinor &v, const DiracSpinor &w,
                    const Coulomb::QkTable &qk,
                    const std::vector<DiracSpinor> &core,
                    const std::vector<DiracSpinor> &excited,
-                   const Angular::SixJTable &SixJ, Denominators denominators);
+                   const Angular::SixJTable &SixJ, Denominators denominators,
+                   const bool &screen = false);
 
 /*!
   @brief Diagram c1 contribution to the reduced two-body Sigma.

--- a/src/MBPT/Sigma2.hpp
+++ b/src/MBPT/Sigma2.hpp
@@ -236,6 +236,7 @@ double e_bar(int kappa_v, const std::vector<DiracSpinor> &excited);
   const std::vector<DiracSpinor> &core, const std::vector<DiracSpinor> &excited,
   const Coulomb::QkTable &qk, int max_k, bool exclude_wrong_parity_box,
   Denominators denominators, const std::vector<MBPT::ComplexRMatrix> &dQ_screen,
+  const std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> &dQ_screen_Fermi,
   bool no_new_integrals = false);
 
 //==============================================================================
@@ -349,10 +350,11 @@ double S_Sigma2_d(int k, const DiracSpinor &v, const DiracSpinor &w,
 
   @return Diagram d contribution to \f$ S^k_{vwxy} \f$.
 */
-double S_Sigma2_screen(int k, const DiracSpinor &v, const DiracSpinor &w,
-                       const DiracSpinor &x, const DiracSpinor &y,
-                       Denominators denominators,
-                       const std::vector<MBPT::ComplexRMatrix> &Q_screen);
+double S_Sigma2_screen(
+  int k, const DiracSpinor &v, const DiracSpinor &w, const DiracSpinor &x,
+  const DiracSpinor &y, const std::vector<DiracSpinor> &excited,
+  Denominators denominators, const std::vector<MBPT::ComplexRMatrix> &Q_screen,
+  const std::vector<LinAlg::Matrix<MBPT::ComplexRMatrix>> &dQ_screen_Fermi);
 
 } // namespace Sigma2
 

--- a/src/MBPT/Sigma2.hpp
+++ b/src/MBPT/Sigma2.hpp
@@ -358,6 +358,12 @@ double S_Sigma2_screen(
 
 } // namespace Sigma2
 
+void FillPiMatrix(const int &max_k_Coulomb,
+                  const std::vector<DiracSpinor> &cis2_basis,
+                  const std::string &cis2_basis_str,
+                  const std::vector<int> &kappai_list, const Feynman &feyn,
+                  std::vector<LinAlg::Matrix<ComplexRMatrix>> &PiMatrix);
+
 } // namespace MBPT
 
 //==============================================================================

--- a/src/MBPT/Sigma2.hpp
+++ b/src/MBPT/Sigma2.hpp
@@ -235,7 +235,7 @@ double e_bar(int kappa_v, const std::vector<DiracSpinor> &excited);
   const std::string &filename, const std::vector<DiracSpinor> &external,
   const std::vector<DiracSpinor> &core, const std::vector<DiracSpinor> &excited,
   const Coulomb::QkTable &qk, int max_k, bool exclude_wrong_parity_box,
-  Denominators denominators, const std::vector<MBPT::ComplexRMatrix> &Q_screen,
+  Denominators denominators, const std::vector<MBPT::ComplexRMatrix> &dQ_screen,
   bool no_new_integrals = false);
 
 //==============================================================================

--- a/src/MBPT/Sigma2.hpp
+++ b/src/MBPT/Sigma2.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "Angular/SixJTable.hpp"
 #include "Coulomb/QkTable.hpp"
+#include "MBPT/Feynman.hpp"
 #include "Wavefunction/DiracSpinor.hpp"
 #include "qip/String.hpp"
 #include <string>
@@ -205,6 +206,37 @@ double e_bar(int kappa_v, const std::vector<DiracSpinor> &excited);
   const Coulomb::QkTable &qk, int max_k, bool exclude_wrong_parity_box,
   Denominators denominators, bool no_new_integrals = false);
 
+/*!
+  @brief Calculates (or reads in) a table of two-body Sigma_2 matrix elements that include screening.
+
+  @details
+  Computes \f$ S^k_{vwxy} \f$ for all relevant combinations of states in
+  @p external, using the provided core and excited bases and Coulomb table.
+  Results are written to / read from @p filename (empty string disables I/O).
+
+  @param filename                 File to read/write the table. (blank for "false" to not write)
+  @param external                 Basis states for external legs (all ME between these are computed).
+  @param core                     Core (hole) states for internal summations.
+  @param excited                  Excited (particle) states for internal summations.
+  @param qk                       Precomputed Coulomb integral table (QkTable).
+  @param max_k                    Maximum multipolarity to include.
+  @param exclude_wrong_parity_box If true, excludes box diagrams with "wrong" parity.
+  @param denominators             RS, Fermi, Fermi0: see \ref MBPT::Denominators
+  @param no_new_integrals         If true, only reads existing intergals; no new computation.
+
+  @note no_new_integrals - if we _know_ all required integrals are already in the 
+  file to be read in, saves time.
+  Otherwise, ampsci will check if any new integrals are requred.
+  This checking can take a while, particularly for large basis.
+
+  @return LkTable containing all computed \f$ S^k_{vwxy} \f$ matrix elements.
+*/
+[[nodiscard]] Coulomb::LkTable calculate_Sk_screened(
+  const std::string &filename, const std::vector<DiracSpinor> &external,
+  const std::vector<DiracSpinor> &core, const std::vector<DiracSpinor> &excited,
+  const Coulomb::QkTable &qk, int max_k, bool exclude_wrong_parity_box,
+  Denominators denominators, MBPT::Feynman feyn, bool no_new_integrals = false);
+
 //==============================================================================
 //==============================================================================
 
@@ -299,6 +331,25 @@ double S_Sigma2_d(int k, const DiracSpinor &v, const DiracSpinor &w,
                   const std::vector<DiracSpinor> &core,
                   const std::vector<DiracSpinor> &excited,
                   const Angular::SixJTable &SixJ, Denominators denominators);
+
+/*!
+  @brief Screened contribution to the reduced two-body Sigma.
+  @details
+  Computes Goldstone diagram d for \f$ S^k_{vwxy} \f$.
+
+  @param k            Multipolarity.
+  @param v            (+ w x y) External spinors.
+  @param qk           Coulomb integral table.
+  @param core         Core states.
+  @param excited      Excited states.
+  @param SixJ         6-j symbol table.
+  @param denominators Energy denominator convention.
+
+  @return Diagram d contribution to \f$ S^k_{vwxy} \f$.
+*/
+double S_Sigma2_screen(int k, const DiracSpinor &v, const DiracSpinor &w,
+                       const DiracSpinor &x, const DiracSpinor &y,
+                       Denominators denominators, const Feynman &feyn);
 
 } // namespace Sigma2
 

--- a/src/Physics/AtomData.cpp
+++ b/src/Physics/AtomData.cpp
@@ -557,7 +557,6 @@ std::vector<std::pair<int, int>> n_kappa_list(const std::string &basis_string) {
 //==============================================================================
 std::vector<int> kappa_list(const std::string &basis_string) {
 
-  std::vector<int> state_list;
   std::vector<int> kappa_list;
   std::string n_str_previous = "999";
   std::string n_str = "";
@@ -576,7 +575,7 @@ std::vector<int> kappa_list(const std::string &basis_string) {
       if (l != 0) {
         kappa_list.emplace_back(l);
       }
-      state_list.emplace_back(-l - 1);
+      kappa_list.emplace_back(-l - 1);
     }
   }
   return kappa_list;
@@ -585,7 +584,6 @@ std::vector<int> kappa_list(const std::string &basis_string) {
 //==============================================================================
 std::vector<int> kappa_index_list(const std::string &basis_string) {
 
-  std::vector<int> state_list;
   std::vector<int> kappa_list;
   std::string n_str_previous = "999";
   std::string n_str = "";
@@ -604,7 +602,7 @@ std::vector<int> kappa_index_list(const std::string &basis_string) {
       if (l != 0) {
         kappa_list.emplace_back(Angular::kappa_to_kindex(l));
       }
-      state_list.emplace_back(Angular::kappa_to_kindex(-l - 1));
+      kappa_list.emplace_back(Angular::kappa_to_kindex(-l - 1));
     }
   }
   return kappa_list;

--- a/src/Physics/AtomData.cpp
+++ b/src/Physics/AtomData.cpp
@@ -555,6 +555,62 @@ std::vector<std::pair<int, int>> n_kappa_list(const std::string &basis_string) {
 }
 
 //==============================================================================
+std::vector<int> kappa_list(const std::string &basis_string) {
+
+  std::vector<int> state_list;
+  std::vector<int> kappa_list;
+  std::string n_str_previous = "999";
+  std::string n_str = "";
+  for (char c : basis_string) {
+    if (std::isdigit(c)) {
+      // if we read a number then ignore it and move on
+      // we only care abourt kappas
+      continue;
+    } else {
+      // if we get a letter then convert the letter to l value
+      auto l_str = std::string(1, c);
+      auto l = AtomData::symbol_to_l(l_str);
+
+      // we place kappa=l (corresponding to lower j) into kappa_list
+      // if l=0 then we will only have kappa=l-1=-1 in list
+      if (l != 0) {
+        kappa_list.emplace_back(l);
+      }
+      state_list.emplace_back(-l - 1);
+    }
+  }
+  return kappa_list;
+}
+
+//==============================================================================
+std::vector<int> kappa_index_list(const std::string &basis_string) {
+
+  std::vector<int> state_list;
+  std::vector<int> kappa_list;
+  std::string n_str_previous = "999";
+  std::string n_str = "";
+  for (char c : basis_string) {
+    if (std::isdigit(c)) {
+      // if we read a number then ignore it and move on
+      // we only care abourt kappas
+      continue;
+    } else {
+      // if we get a letter then convert the letter to l value
+      auto l_str = std::string(1, c);
+      auto l = AtomData::symbol_to_l(l_str);
+
+      // we place kappa=l (corresponding to lower j) into kappa_list
+      // if l=0 then we will only have kappa=l-1=-1 in list
+      if (l != 0) {
+        kappa_list.emplace_back(Angular::kappa_to_kindex(l));
+      }
+      state_list.emplace_back(Angular::kappa_to_kindex(-l - 1));
+    }
+  }
+  return kappa_list;
+}
+
+//==============================================================================
 inline std::string helper_s(const Element &el) {
   auto sym = el.symbol;
   auto sym_buff = (sym.length() == 1) ? std::string("  ") : std::string(" ");

--- a/src/Physics/AtomData.hpp
+++ b/src/Physics/AtomData.hpp
@@ -126,4 +126,12 @@ std::vector<DiracConfig> listOfStates_singlen(const std::string &in_list);
 //! e.g., 6sp5d ->{{6,-1}, {6,1}, {6,-2}, {5,2}, {5,-2}}
 std::vector<std::pair<int, int>> n_kappa_list(const std::string &basis_string);
 
+//! Given a "basis string", returns list of only kappa in the list.
+//! e.g., 12spdf -> {-1, 1, -2, 2, -3, 3, -4}
+std::vector<int> kappa_list(const std::string &basis_string);
+
+//! Given a "basis string", returns list of kappa_index in the list.
+//! e.g., 12spdf -> {0, 1, 2, 3, 4, 5, 6}
+std::vector<int> kappa_index_list(const std::string &basis_string);
+
 } // namespace AtomData

--- a/src/buildOptions.mk
+++ b/src/buildOptions.mk
@@ -1,7 +1,7 @@
 # BUILD OPTIONS:
 
 ## c++ standard. must be at least c++17
-CXXSTD ?= -std=c++17
+CXXSTD ?= -std=c++20
 
 ## Set directories for source files (SRC), and output built object files (BUILD)
 SRC = ./src

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,19 +143,19 @@ void print_manual(bool details = true) {
   const int wrap_at = 80;
   std::string tab = "    ";
   fmt2::styled_print(fmt::emphasis::bold, "NAME\n");
-  fmt::print(qip::wrap(name, wrap_at, tab + tab));
+  fmt::print("{}", qip::wrap(name, wrap_at, tab + tab));
 
   std::cout << "\n\n";
 
   fmt2::styled_print(fmt::emphasis::bold, "SYNOPSIS\n");
-  fmt::print(qip::wrap(synopsis, wrap_at, tab + tab));
+  fmt::print("{}", qip::wrap(synopsis, wrap_at, tab + tab));
   std::cout << "\n";
 
   if (details) {
     std::cout << "\n";
 
     fmt2::styled_print(fmt::emphasis::bold, "DESCRIPTION\n");
-    fmt::print(qip::wrap(description, wrap_at, tab + tab));
+    fmt::print("{}", qip::wrap(description, wrap_at, tab + tab));
 
     std::cout << "\n\n";
 
@@ -164,14 +164,14 @@ void print_manual(bool details = true) {
       fmt2::styled_print(fg(fmt::color::steel_blue),
                          qip::wrap(option, wrap_at, tab + tab));
       std::cout << "\n";
-      fmt::print(qip::wrap(text, wrap_at, tab + tab + tab));
+      fmt::print("{}", qip::wrap(text, wrap_at, tab + tab + tab));
       std::cout << "\n";
     }
   }
 
   std::cout << "\n";
   fmt2::styled_print(fmt::emphasis::bold, "AUTHOR\n");
-  fmt::print(qip::wrap(author, wrap_at, tab + tab));
+  fmt::print("{}", qip::wrap(author, wrap_at, tab + tab));
 
   std::cout << "\n";
 }


### PR DESCRIPTION
Sorry for late night pull request. I've listed some things that might be problems/I think might be confusing.

- The frequency-dependent Breit stuff is a pretty small change but required adding new method to vBr to get the scaling factor for frequency, and then also required changing the way that the matrix elements of h1 are calculated inside CI. Instead of assuming eigenstates, now just directly calculate the matrix element <v|h0|w>
- Because the function that calculates this that already existed would also include the correlation potential if it already existed, I also had to have it not then separately include the <v|Sigma|w> matrix element if we had it already. This is the one change that I'm least sure I did correctly (might be some cases where it doesn't include Sigma when it should so we might need to talk about that/you can just change it). Could also just write a new function for <a|H|b> that never includes the correlation potential to avoid the issue I've created
- For the screening into CI, I added a flag in the Feynman constructor that is true/false for if we want to use it for CI, in which case it won't bother calculating QPiQ and writing it to a file. I added this flag not at the end but after the flag for include_g since there are a bunch of other default options that are left out at the end, and I was too lazy to go through everywhere that those weren't called and give them values so that I could specify that I didn't want "for_CI = true," if that makes sense. Sorry if that's painful to deal with

Last thing is that I think that I think we should write the Pi table that we calculate if we want the Fermi denominators in the screening I added into Sigma^2 to a file.